### PR TITLE
Fix CI safety, stale config, and doc drift

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,8 @@
 {
-  "name": "Blessed Dives",
+  "name": "MotherDuck Blueprints",
   "image": "mcr.microsoft.com/devcontainers/typescript-node:20",
   "containerEnv": {
-    "DUCKDB_VERSION": "v1.4.4"
+    "DUCKDB_VERSION": "v1.5.3"
   },
   "postCreateCommand": "/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/NiclasHaderer/duckdb-version-manager/main/install.sh)\" && duckman install ${DUCKDB_VERSION} && duckman default ${DUCKDB_VERSION} && make setup",
   "forwardPorts": [5173],

--- a/.dive-preview/src/main.tsx
+++ b/.dive-preview/src/main.tsx
@@ -1,9 +1,10 @@
 import { createRoot } from "react-dom/client";
+import type { ReactNode } from "react";
 import { MotherDuckSDKProvider, useConnectionStatus } from "./md-sdk";
 import { Loader2, AlertCircle } from "lucide-react";
 import Dive from "./dive";
 
-function ConnectionGate({ children }: { children: React.ReactNode }) {
+function ConnectionGate({ children }: { children: ReactNode }) {
   const { isConnected, isConnecting, error } = useConnectionStatus();
   if (isConnecting) return (
     <div className="flex items-center justify-center h-screen gap-2 text-[#6a6a6a]">

--- a/.github/workflows/deploy_bundles.yaml
+++ b/.github/workflows/deploy_bundles.yaml
@@ -4,6 +4,12 @@ permissions:
   contents: read
   pull-requests: write
 
+# Cancel superseded preview runs for the same PR, but never cancel an
+# in-flight production (main) or manually dispatched deploy.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/deploy_dives.yaml
+++ b/.github/workflows/deploy_dives.yaml
@@ -4,6 +4,12 @@ permissions:
   pull-requests: write
   contents: read
 
+# Cancel superseded preview runs for the same PR, but never cancel an
+# in-flight production (main) or manually dispatched deploy.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/deploy_flights.yaml
+++ b/.github/workflows/deploy_flights.yaml
@@ -4,6 +4,12 @@ permissions:
   contents: read
   pull-requests: write
 
+# Cancel superseded preview runs for the same PR, but never cancel an
+# in-flight production (main) or manually dispatched deploy.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   workflow_dispatch:
   push:

--- a/README.md
+++ b/README.md
@@ -49,11 +49,15 @@ context/
   schemas/
 
 scripts/
-  deploy-bundle.sh
-  cleanup-preview-bundle.sh
   deploy-dive.sh
   deploy-flight.sh
+  deploy-bundle.sh
   validate-flight.sh
+  validate-bundle.sh
+  cleanup-preview-dive.sh
+  cleanup-preview-flight.sh
+  cleanup-preview-bundle.sh
+  mock-test.sh
 ```
 
 ## Local Dive Preview

--- a/bundles/wikipedia-pageviews/blueprint.json
+++ b/bundles/wikipedia-pageviews/blueprint.json
@@ -10,7 +10,6 @@
     {
       "name": "wikipedia-pageviews",
       "path": "flights/wikipedia-pageviews",
-      "runBeforeDives": true,
       "waitForShares": [
         {
           "production": "wikipedia_pageviews",

--- a/flights/wikipedia-pageviews/flight.py
+++ b/flights/wikipedia-pageviews/flight.py
@@ -33,7 +33,7 @@ DEFAULT_CONFIG = {
     "share_visibility": "DISCOVERABLE",
     "user_agent": (
         "motherduck-blueprints-wikipedia-pageviews/1.0 "
-        "(https://github.com/your-org/motherduck-blueprints)"
+        "(https://github.com/motherduckdb/motherduck-blueprints)"
     ),
 }
 

--- a/flights/wikipedia-pageviews/flight_metadata.json
+++ b/flights/wikipedia-pageviews/flight_metadata.json
@@ -17,7 +17,7 @@
     "share": "wikipedia_pageviews",
     "share_access": "ORGANIZATION",
     "share_visibility": "DISCOVERABLE",
-    "user_agent": "motherduck-blueprints-wikipedia-pageviews/1.0 (https://github.com/your-org/motherduck-blueprints)"
+    "user_agent": "motherduck-blueprints-wikipedia-pageviews/1.0 (https://github.com/motherduckdb/motherduck-blueprints)"
   },
   "preview": {
     "enabled": true,

--- a/scripts/deploy-flight.sh
+++ b/scripts/deploy-flight.sh
@@ -72,11 +72,11 @@ CONFIG_SQL=$(jq -r \
   def template:
     gsub("\\$\\{PREVIEW_BRANCH\\}"; $preview_branch)
     | gsub("\\$\\{BRANCH_SLUG\\}"; $branch_slug);
-  if $preview_mode == "true" then
+  (if $preview_mode == "true" then
     ((.config // {}) + (.preview.config // {}))
   else
     (.config // {})
-  end as $config
+  end) as $config
   | if ($config | length) == 0 then
       "map([]::VARCHAR[], []::VARCHAR[])"
     else


### PR DESCRIPTION
Repo audit pass over CI, config, the example blueprint, and docs. Opening this PR surfaced a real deploy-breaking bug (see CI fix below).

## Changes

**CI bug fix (surfaced by this PR's own run)**
- `scripts/deploy-flight.sh`: the config builder used `if … end as $config`, which the `jq` on GitHub's ubuntu runners rejects (`unexpected as`). Newer local `jq` accepts it, so `make mock-test` masked the bug. Parenthesized to `(if … end) as $config`, valid on every `jq` version. Confirmed: after the fix, the deploy job parses cleanly and now fails only at the MotherDuck connection step (see "Setup note").

**CI improvement**
- Fork-safe `concurrency` on `deploy_dives`, `deploy_flights`, `deploy_bundles`: superseded PR-preview runs are cancelled (they mutate the same branch-scoped Dive/Flight/share by name and can race), while `main` (production) and `workflow_dispatch` runs are never cancelled.

**Staleness / correctness**
- `.devcontainer/devcontainer.json`: rename leftover `"Blessed Dives"` → `"MotherDuck Blueprints"` (a prior commit was *"Remove blessed Dives references"* and missed this one); bump `DUCKDB_VERSION` `v1.4.4` → `v1.5.3` to match CI (the `MD_*` functions are version-sensitive).
- `flights/wikipedia-pageviews/{flight.py,flight_metadata.json}`: Wikimedia `user_agent` pointed at a non-existent `github.com/your-org/...`; this example runs in prod via `runOnDeploy: true`, so it now points at `motherduckdb/motherduck-blueprints`.
- `bundles/wikipedia-pageviews/blueprint.json`: remove dead `"runBeforeDives": true` — no script or validator reads it; `deploy-bundle.sh` always orders Flights → shares → Dives.

**Docs / consistency**
- `README.md`: complete the scripts list in *Repository Layout* (it omitted 4 of 9 scripts).
- `.dive-preview/src/main.tsx`: import `ReactNode` rather than referencing the un-imported `React` namespace (matches `md-sdk.tsx`).

## Verification
- `make mock-test` passes locally.
- This PR's CI: `Identify Changed Bundles` + `Validate Bundles` pass; `Deploy Preview Bundles` now gets past `jq` and fails only with *"Cannot connect to MotherDuck server: no token provided"* — i.e. the missing repo secret, not a code bug.

## Setup note (not code)
- The `MOTHERDUCK_TOKEN` repository secret is **not configured** in this repo, so preview/production deploy jobs can't reach MotherDuck. Add it (service-account token) per `docs/customer-onboarding.md` to enable deploys. No live MotherDuck resources were created by this PR.

## Intentionally left as-is
- `dorny/paths-filter` `base: main` on push-to-main — verified against the action docs this is the correct config (diffs against the pre-push commit), so production deploys do fire.
- `.github/CODEOWNERS` placeholders — documented template step.