### PR TITLE
fix(workflows): skip deploy jobs without token

### DIFF
--- a/.github/workflows/cleanup_preview_blueprints.yaml
+++ b/.github/workflows/cleanup_preview_blueprints.yaml
@@ -31,4 +31,8 @@ jobs:
             echo "No branch name available for cleanup"
             exit 0
           fi
+          if [ -z "$MOTHERDUCK_TOKEN" ]; then
+            echo "Preview cleanup skipped because MOTHERDUCK_TOKEN is not configured for this repository."
+            exit 0
+          fi
           ./tools/md_blueprints cleanup --target preview --branch "$BRANCH_NAME"

--- a/.github/workflows/deploy_blueprints.yaml
+++ b/.github/workflows/deploy_blueprints.yaml
@@ -187,4 +187,8 @@ jobs:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
           BLUEPRINTS: ${{ needs.compute_changes.outputs.changed_csv }}
         run: |
+          if [ -z "$MOTHERDUCK_TOKEN" ]; then
+            echo "Production deploy skipped because MOTHERDUCK_TOKEN is not configured for this repository."
+            exit 0
+          fi
           ./tools/md_blueprints deploy --target prod --blueprints "$BLUEPRINTS"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Update this file in every pull request. Add entries under `Unreleased` until the
 ### Changed
 
 - Migrated the Wikipedia Pageviews example into `blueprints/wikipedia-pageviews/`.
+- Skipped production deployment and preview cleanup workflows when `MOTHERDUCK_TOKEN` is not configured.
 - Simplified the README into a customer-facing quickstart and moved detailed repository mechanics into `docs/repository-reference.md`.
 - Reworded blueprint documentation to describe the project-first layout without external product comparisons.
 - Replaced type-first Dives, Flights, and bundles documentation with project-level blueprint guidance.


### PR DESCRIPTION
fix the template repository workflows so unconfigured customer/template repos do not fail production deploy or preview cleanup when MOTHERDUCK_TOKEN has not been added yet.

### Codex description

- skip production deployment when MOTHERDUCK_TOKEN is absent
- skip preview cleanup when MOTHERDUCK_TOKEN is absent
- document the workflow behavior in CHANGELOG.md
