### PR TITLE
docs: make setup language self-service

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,4 +69,4 @@ CI calls `tools/md_blueprints` directly for change detection, validation, previe
 
 ## Changelog
 
-Update `CHANGELOG.md` in every pull request. Keep entries under `Unreleased` until the change is released or merged into a customer template.
+Update `CHANGELOG.md` in every pull request. Keep entries under `Unreleased` until the change is released or merged into a reusable template.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this repository are documented here.
 
-Update this file in every pull request. Add entries under `Unreleased` until the change is released or merged into a customer template.
+Update this file in every pull request. Add entries under `Unreleased` until the change is released or merged into a reusable template.
 
 ## Unreleased
 
@@ -18,7 +18,8 @@ Update this file in every pull request. Add entries under `Unreleased` until the
 
 - Migrated the Wikipedia Pageviews example into `blueprints/wikipedia-pageviews/`.
 - Skipped production deployment and preview cleanup workflows when `MOTHERDUCK_TOKEN` is not configured.
-- Simplified the README into a customer-facing quickstart and moved detailed repository mechanics into `docs/repository-reference.md`.
+- Reworked setup language for self-service use in your own repository.
+- Simplified the README into a self-service quickstart and moved detailed repository mechanics into `docs/repository-reference.md`.
 - Reworded blueprint documentation to describe the project-first layout without external product comparisons.
 - Replaced type-first Dives, Flights, and bundles documentation with project-level blueprint guidance.
 - Documented that blueprint packages represent one logical project or data product, not an organization, service account, user, or database owner.

--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 A lightweight template for shipping MotherDuck Flights, Dives, shares, and future context assets from GitHub.
 
-Use this repo when a customer wants:
+Use this repo when you want:
 
 - version-controlled MotherDuck projects
 - preview deployments on pull requests
 - production deployments from `main`
 - one clear place to keep each data product's code and metadata
 
-## Start a Customer Repo
+## Start Your Repo
 
-1. Copy this repository into the customer's GitHub organization.
+1. Copy this repository into your GitHub organization.
 2. Add a GitHub Actions secret named `MOTHERDUCK_TOKEN`.
 3. Create a GitHub Environment named `motherduck-production`.
 4. Run the local checks:
@@ -23,9 +23,9 @@ make mock-test
 
 5. Open a small pull request and confirm the preview deployment comment appears.
 
-Use a MotherDuck service account token for shared repositories so deployed resources are owned by automation rather than by one person's account.
+Use a MotherDuck service account token so deployed resources are owned by automation rather than by one person's account.
 
-See [Customer Onboarding](docs/customer-onboarding.md) for the full setup flow and [GitHub Setup](docs/github-setup.md) for the short GitHub checklist.
+See [Set Up Your Repository](docs/setup-your-repository.md) for the full setup flow and [GitHub Setup](docs/github-setup.md) for the short GitHub checklist.
 
 ## Add a Blueprint
 
@@ -49,12 +49,12 @@ make validate
 make preview-smoke revenue-overview
 ```
 
-Then replace the starter Flight and Dive with the customer's real project logic.
+Then replace the starter Flight and Dive with your real project logic.
 
 ## Best Practices to Copy
 
 - Keep one project or data product per `blueprints/<name>/` package.
-- Use lowercase slug names such as `customer-360` or `revenue-ops`.
+- Use lowercase slug names such as `account-360` or `revenue-ops`.
 - Keep preview resources branch-scoped and production resources stable.
 - Deploy from CI with a service account token.
 - Store secrets in GitHub Actions, never in the repo.
@@ -64,10 +64,10 @@ Then replace the starter Flight and Dive with the customer's real project logic.
 
 The included [Wikipedia Pageviews blueprint](blueprints/wikipedia-pageviews/README.md) shows a Flight that loads public data, publishes a share, and deploys a Dive that reads that share.
 
-For a new customer project, the generated starter blueprint is usually the best first example because it is small, deployable, and easy to replace.
+For a new project, the generated starter blueprint is usually the best first example because it is small, deployable, and easy to replace.
 
 ## More Detail
 
-- [Customer Onboarding](docs/customer-onboarding.md): copy this template into a customer-owned repo.
+- [Set Up Your Repository](docs/setup-your-repository.md): copy this template into your repo.
 - [GitHub Setup](docs/github-setup.md): configure secrets, environments, and branch protection.
 - [Repository Reference](docs/repository-reference.md): layout, targets, local commands, CI/CD, and context-layer notes.

--- a/docs/examples/wikipedia-pageviews.md
+++ b/docs/examples/wikipedia-pageviews.md
@@ -26,7 +26,7 @@ The Flight uses the Wikimedia Pageviews API:
 https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/...
 ```
 
-The default article set is `DuckDB`, `MotherDuck`, and `Wikipedia` for the last 30 complete days. Wikimedia asks API clients to send a useful `User-Agent`, so update `variables.user_agent` in `blueprint.yml` before deploying this from a real customer repository.
+The default article set is `DuckDB`, `MotherDuck`, and `Wikipedia` for the last 30 complete days. Wikimedia asks API clients to send a useful `User-Agent`, so update `variables.user_agent` in `blueprint.yml` before deploying this from your repository.
 
 ## Deployment Flow
 

--- a/docs/github-setup.md
+++ b/docs/github-setup.md
@@ -2,7 +2,7 @@
 
 ## 1. Create the Repository
 
-For a customer-owned repo, prefer creating a new repository from the MotherDuck Blueprints template. See [customer-onboarding.md](customer-onboarding.md) for the full template-copy flow.
+Prefer creating your repository from the MotherDuck Blueprints template. See [setup-your-repository.md](setup-your-repository.md) for the full template-copy flow.
 
 If you are pushing from a local copy manually, create an empty GitHub repository named `motherduck-blueprints`, then push this folder to it.
 
@@ -11,7 +11,7 @@ git init
 git add .
 git commit -m "Initial MotherDuck Blueprints repo"
 git branch -M main
-git remote add origin git@github.com:<owner>/motherduck-blueprints.git
+git remote add origin git@github.com:<your-org>/motherduck-blueprints.git
 git push -u origin main
 ```
 
@@ -24,7 +24,7 @@ In GitHub:
 3. Create a repository secret named `MOTHERDUCK_TOKEN`.
 4. Paste a MotherDuck read/write token.
 
-Use a service account token for shared repositories so deployed resources are owned by automation rather than by an individual user.
+Use a service account token so deployed resources are owned by automation rather than by an individual user.
 
 ## 3. Add Production Environment Approval
 

--- a/docs/repository-reference.md
+++ b/docs/repository-reference.md
@@ -38,7 +38,7 @@ context/
 
 A `blueprints/<name>/` package represents one logical project or data product that should be reviewed, previewed, deployed, rolled back, and understood as a unit.
 
-Use a blueprint package for examples like `customer-360`, `revenue-ops`, `support-insights`, or `wikipedia-pageviews`. Do not use a blueprint package for an entire organization, all databases owned by a user, all resources owned by a service account, or all production assets across unrelated projects.
+Use a blueprint package for examples like `account-360`, `revenue-ops`, `support-insights`, or `wikipedia-pageviews`. Do not use a blueprint package for an entire organization, all databases owned by a user, all resources owned by a service account, or all production assets across unrelated projects.
 
 A single MotherDuck user or service account can own many databases, and one project can occasionally involve more than one service account. That does not change the package boundary:
 

--- a/docs/setup-your-repository.md
+++ b/docs/setup-your-repository.md
@@ -1,26 +1,26 @@
-# Customer Onboarding
+# Set Up Your Repository
 
-This repository is intended to act as a reusable MotherDuck Blueprints template. Customers copy it into their own GitHub organization, connect it to MotherDuck with a service account token, then customize or add blueprint packages under `blueprints/`.
+This repository is a reusable MotherDuck Blueprints template. Copy it into your GitHub organization, connect it to MotherDuck with a service account token, then customize or add blueprint packages under `blueprints/`.
 
-Blueprints are project-level packages. Each package should represent one logical project or data product, not an entire organization, service account, user, or database owner. Do not create top-level `dives/`, `flights/`, or `bundles/` directories in customer repos.
+Blueprints are project-level packages. Each package should represent one logical project or data product, not an entire organization, service account, user, or database owner. Do not create top-level `dives/`, `flights/`, or `bundles/` directories in your repo.
 
 ## 1. Copy the Template Repo
 
-Create a customer-owned repository from the template.
+Create your repository from the template.
 
 Recommended GitHub flow once `motherduckdb/motherduck-blueprints` is public:
 
 1. Open the template repository.
 2. Click "Use this template".
-3. Select the customer's GitHub organization.
+3. Select your GitHub organization.
 4. Name the new repository, for example `motherduck-blueprints`.
-5. Create the repository as private unless the customer explicitly wants it public.
+5. Create the repository as private unless you want it public.
 
 CLI alternative:
 
 ```bash
-gh repo create <customer-org>/motherduck-blueprints --private --template motherduckdb/motherduck-blueprints
-git clone git@github.com:<customer-org>/motherduck-blueprints.git
+gh repo create <your-org>/motherduck-blueprints --private --template motherduckdb/motherduck-blueprints
+git clone git@github.com:<your-org>/motherduck-blueprints.git
 cd motherduck-blueprints
 ```
 
@@ -30,12 +30,12 @@ If GitHub template mode is not enabled yet, copy by clone and push:
 git clone git@github.com:motherduckdb/motherduck-blueprints.git motherduck-blueprints
 cd motherduck-blueprints
 git remote remove origin
-gh repo create <customer-org>/motherduck-blueprints --private --source . --remote origin --push
+gh repo create <your-org>/motherduck-blueprints --private --source . --remote origin --push
 ```
 
 ## 2. Create a MotherDuck Service Account Token
 
-In the customer's MotherDuck organization:
+In your MotherDuck organization:
 
 1. Create a service account for CI deployments.
 2. Grant it the minimum database privileges needed by the blueprints.
@@ -46,7 +46,7 @@ Use a service account token rather than a personal token so deployed Dives, Flig
 
 ## 3. Add GitHub Secrets
 
-In the customer repository:
+In your repository:
 
 1. Open Settings.
 2. Open Secrets and variables, then Actions.
@@ -87,7 +87,7 @@ make mock-test
 
 `make validate` checks manifests and rendered targets. `make mock-test` shadows `duckdb` with a fake CLI and exercises preview deploy, production deploy, cleanup, and failed-run reporting without contacting MotherDuck.
 
-If the customer keeps a Dive in the repo, also run a finite local preview build:
+If you keep a Dive in the repo, also run a finite local preview build:
 
 ```bash
 make preview-smoke <blueprint-name>
@@ -97,7 +97,7 @@ PR validation still runs if `MOTHERDUCK_TOKEN` has not been added yet, but live 
 
 ## 7. Run a Preview PR
 
-Create a branch in the customer repo and make a small change, for example edit the Wikipedia blueprint docs or metadata.
+Create a branch in your repo and make a small change, for example edit the Wikipedia blueprint docs or metadata.
 
 ```bash
 git checkout -b test/wikipedia-blueprint
@@ -144,10 +144,10 @@ Expected production flow:
 
 ## 10. Customize the Blueprints
 
-Customers can then:
+You can then:
 
 - Scaffold a starter package with `make new-blueprint <blueprint-name>`. The generated Flight creates a tiny metrics table and share, and the generated Dive reads that share.
-- Replace the Wikipedia example with their own blueprint package.
+- Replace the Wikipedia example with your own blueprint package.
 - Add standalone Dives or Flights as one-resource blueprints.
 - Add paired Flight + Dive packages that declare shared data products in `resources.shares`.
 - Version context-layer assets under `context/` or package-local `resources.context` entries with `deploy: false`.


### PR DESCRIPTION
Reframe the repository setup docs for users copying the template into their own repositories, without MotherDuck-internal customer hand-off language.

### Codex description

- rename the onboarding guide to a self-service repository setup guide
- update README, GitHub setup, reference, example, and changelog wording for direct user ownership