### PR TITLE
feat(blueprints): improve starter example and ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,58 @@
+name: CI
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "motherduck.yml"
+      - "Makefile"
+      - "blueprints/**"
+      - "schemas/**"
+      - "tools/**"
+      - "scripts/**"
+      - "templates/**"
+      - ".dive-preview/**"
+      - ".github/workflows/*.yaml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "motherduck.yml"
+      - "Makefile"
+      - "blueprints/**"
+      - "schemas/**"
+      - "tools/**"
+      - "scripts/**"
+      - "templates/**"
+      - ".dive-preview/**"
+      - ".github/workflows/*.yaml"
+
+jobs:
+  checks:
+    name: Validate and Smoke Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: .dive-preview/package-lock.json
+
+      - name: Validate manifests
+        run: make validate
+
+      - name: Run mock deployment tests
+        run: make mock-test
+
+      - name: Build included example Dive
+        run: make preview-smoke wikipedia-pageviews
+
+      - name: Create and destroy generated example
+        run: make example-smoke

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ Use these commands before opening PRs:
 ```bash
 make validate
 make mock-test
+make example-smoke
 ```
 
 When a blueprint includes a Dive, also run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Update this file in every pull request. Add entries under `Unreleased` until the
 
 ### Added
 
+- Added CI coverage that validates manifests, mock deploys, builds the included Dive, and creates then destroys a generated starter blueprint.
+- Added `make example-smoke` to prove the generated starter blueprint can be created, rendered, built, and removed.
+- Added a generated blueprint README template.
 - Added a complete `blueprint.yml` field reference for agents, LLM crawlers, and blueprint authors.
 - Introduced project-first blueprint packages under `blueprints/<name>/`.
 - Added the root `motherduck.yml` repository manifest, JSON schemas, and `tools/md_blueprints`.
@@ -17,6 +20,7 @@ Update this file in every pull request. Add entries under `Unreleased` until the
 
 ### Changed
 
+- Expanded the generated starter blueprint with daily metrics, a summary view, an underscore-safe Dive alias, and a richer dashboard.
 - Migrated the Wikipedia Pageviews example into `blueprints/wikipedia-pageviews/`.
 - Skipped production deployment and preview cleanup workflows when `MOTHERDUCK_TOKEN` is not configured.
 - Reworked setup language for self-service use in your own repository.

--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,16 @@ new-blueprint: ## Scaffold a new blueprint package (e.g. make new-blueprint reve
 	@test ! -d "blueprints/$(ARG)" || { echo "Blueprint already exists: blueprints/$(ARG)"; exit 1; }
 	mkdir -p blueprints/$(ARG)/src
 	cp templates/blueprint/blueprint.yml blueprints/$(ARG)/blueprint.yml
+	cp templates/blueprint/README.md blueprints/$(ARG)/README.md
 	cp templates/blueprint/flight.py blueprints/$(ARG)/src/flight.py
 	cp templates/blueprint/requirements.txt blueprints/$(ARG)/src/requirements.txt
 	cp templates/blueprint/dive.tsx blueprints/$(ARG)/src/dive.tsx
-	@perl -pi -e 's/__BLUEPRINT_NAME__/$(ARG)/g; s/__DATABASE_NAME__/$(DB_NAME)/g' blueprints/$(ARG)/blueprint.yml blueprints/$(ARG)/src/flight.py blueprints/$(ARG)/src/dive.tsx
+	@perl -pi -e 's/__BLUEPRINT_NAME__/$(ARG)/g; s/__DATABASE_NAME__/$(DB_NAME)/g' blueprints/$(ARG)/blueprint.yml blueprints/$(ARG)/README.md blueprints/$(ARG)/src/flight.py blueprints/$(ARG)/src/dive.tsx
 	@echo "Created blueprints/$(ARG). Run make validate before opening a PR."
+
+.PHONY: example-smoke
+example-smoke: ## Create, validate, build, and destroy a generated blueprint example
+	./scripts/scaffold-smoke-test.sh
 
 .PHONY: validate
 validate: ## Validate all blueprint manifests without contacting MotherDuck

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Start with the scaffold:
 ```bash
 make new-blueprint revenue-overview
 make validate
+make example-smoke
 make preview-smoke revenue-overview
 ```
 
@@ -64,7 +65,7 @@ Then replace the starter Flight and Dive with your real project logic.
 
 The included [Wikipedia Pageviews blueprint](blueprints/wikipedia-pageviews/README.md) shows a Flight that loads public data, publishes a share, and deploys a Dive that reads that share.
 
-For a new project, the generated starter blueprint is usually the best first example because it is small, deployable, and easy to replace.
+For a new project, the generated starter blueprint is usually the best first example because it is small, deployable, and easy to replace. `make example-smoke` creates that starter in an isolated temp copy, validates it, builds its Dive, and removes it again.
 
 ## More Detail
 

--- a/docs/repository-reference.md
+++ b/docs/repository-reference.md
@@ -70,7 +70,7 @@ make new-blueprint <blueprint-name>
 
 Then edit `blueprints/<blueprint-name>/blueprint.yml` and the files under `src/`.
 
-The generated package is the recommended starting example. It creates a small `starter_metrics` table, publishes a branch- or production-scoped share, and deploys a Dive that reads the share. Replace the starter data and query with your project logic while keeping the same package boundary: one logical project or data product per blueprint.
+The generated package is the recommended starting example. It creates a small `starter_daily_metrics` table and `starter_metric_summary` view, publishes a branch- or production-scoped share, and deploys a Dive that reads the share. Replace the starter data and query with your project logic while keeping the same package boundary: one logical project or data product per blueprint.
 
 For every accepted `blueprint.yml` field, value shape, default, and rendered validation rule, see [blueprint.yml Reference](blueprint-yml-reference.md).
 
@@ -90,6 +90,7 @@ make setup
 make preview <blueprint-name>
 make preview-smoke <blueprint-name>
 make new-blueprint <blueprint-name>
+make example-smoke
 make validate
 make render-preview <blueprint-name>
 make mock-test
@@ -101,16 +102,20 @@ make mock-test
 
 `make mock-test` shadows `duckdb` with a fake CLI and exercises validation, preview deploy, production deploy, cleanup, and failed Flight run reporting without contacting MotherDuck.
 
+`make example-smoke` creates a generated starter blueprint in an isolated temporary copy, validates its rendered preview target, builds its Dive, destroys the generated package, and validates the repository again.
+
 Run this minimum set before opening a PR:
 
 ```bash
 make validate
 make mock-test
+make example-smoke
 make preview-smoke <blueprint-name> # when the blueprint has a Dive
 ```
 
 ## CI/CD Flow
 
+- The `CI` workflow validates manifests, runs mock deployment tests, builds the included example Dive, and creates then destroys a generated starter blueprint.
 - Pull requests validate all manifests, discover changed blueprint packages from `motherduck.yml`, deploy the `preview` target, and comment with preview links.
 - Preview cleanup runs when a PR closes or a branch is deleted. Dives are deleted before Flights, shares, and preview databases.
 - Pushes to `main` deploy the `prod` target through the protected `motherduck-production` environment.

--- a/docs/setup-your-repository.md
+++ b/docs/setup-your-repository.md
@@ -83,9 +83,10 @@ Before touching MotherDuck, run:
 ```bash
 make validate
 make mock-test
+make example-smoke
 ```
 
-`make validate` checks manifests and rendered targets. `make mock-test` shadows `duckdb` with a fake CLI and exercises preview deploy, production deploy, cleanup, and failed-run reporting without contacting MotherDuck.
+`make validate` checks manifests and rendered targets. `make mock-test` shadows `duckdb` with a fake CLI and exercises preview deploy, production deploy, cleanup, and failed-run reporting without contacting MotherDuck. `make example-smoke` creates, validates, builds, and destroys a generated starter blueprint in a temporary copy of the repo.
 
 If you keep a Dive in the repo, also run a finite local preview build:
 
@@ -146,7 +147,7 @@ Expected production flow:
 
 You can then:
 
-- Scaffold a starter package with `make new-blueprint <blueprint-name>`. The generated Flight creates a tiny metrics table and share, and the generated Dive reads that share.
+- Scaffold a starter package with `make new-blueprint <blueprint-name>`. The generated Flight creates daily metric tables and a share, and the generated Dive reads that share.
 - Replace the Wikipedia example with your own blueprint package.
 - Add standalone Dives or Flights as one-resource blueprints.
 - Add paired Flight + Dive packages that declare shared data products in `resources.shares`.

--- a/scripts/scaffold-smoke-test.sh
+++ b/scripts/scaffold-smoke-test.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Create, validate, build, and destroy a generated blueprint package.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+SCAFFOLD_ROOT="${TMP_DIR}/repo"
+EXAMPLE_NAME="${1:-ci-generated-example}"
+DATABASE_NAME="${EXAMPLE_NAME//-/_}"
+BRANCH_NAME="feature/generated-example"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+rsync -a \
+  --exclude .git \
+  --exclude .dive-preview/.env \
+  --exclude .dive-preview/dist \
+  --exclude .dive-preview/node_modules \
+  "$REPO_ROOT/" "$SCAFFOLD_ROOT/"
+
+echo "==> Creating generated blueprint example"
+make -C "$SCAFFOLD_ROOT" new-blueprint "$EXAMPLE_NAME"
+test -f "$SCAFFOLD_ROOT/blueprints/$EXAMPLE_NAME/README.md"
+
+if grep -R "__BLUEPRINT_NAME__\|__DATABASE_NAME__" "$SCAFFOLD_ROOT/blueprints/$EXAMPLE_NAME"; then
+  echo "Generated blueprint still contains template placeholders" >&2
+  exit 1
+fi
+
+echo "==> Validating generated blueprint example"
+make -C "$SCAFFOLD_ROOT" validate
+"$SCAFFOLD_ROOT/tools/md_blueprints" render \
+  --root "$SCAFFOLD_ROOT" \
+  --target preview \
+  --branch "$BRANCH_NAME" \
+  --blueprints "$EXAMPLE_NAME" > "$TMP_DIR/render.out"
+grep -q "${DATABASE_NAME}_preview_feature_generated_example" "$TMP_DIR/render.out"
+grep -q "\"alias\": \"${DATABASE_NAME}\"" "$TMP_DIR/render.out"
+grep -q '"scheduleCron": ""' "$TMP_DIR/render.out"
+
+echo "==> Building generated blueprint Dive"
+make -C "$SCAFFOLD_ROOT" preview-smoke "$EXAMPLE_NAME"
+
+echo "==> Destroying generated blueprint example"
+rm -rf "$SCAFFOLD_ROOT/blueprints/$EXAMPLE_NAME"
+test ! -e "$SCAFFOLD_ROOT/blueprints/$EXAMPLE_NAME"
+make -C "$SCAFFOLD_ROOT" validate
+
+echo "Generated blueprint example smoke test passed."

--- a/templates/blueprint/README.md
+++ b/templates/blueprint/README.md
@@ -1,0 +1,25 @@
+# __BLUEPRINT_NAME__ Blueprint
+
+This generated blueprint is a complete starter project. It deploys a Flight that writes sample daily metrics, publishes the database as a share, and deploys a Dive that reads that share through the `__DATABASE_NAME__` alias.
+
+## Resources
+
+- Flight: `loader`
+- Share: `data`
+- Dive: `dashboard`
+
+The production target writes to the stable `__DATABASE_NAME__` database and share. The preview target writes to `__DATABASE_NAME___preview_${target.branch_slug}`, disables schedules, runs once on deploy, and cleans up the preview share and database when the branch closes.
+
+## Replace the Starter Logic
+
+- Update `src/flight.py` with your real load or transformation code.
+- Update `src/dive.tsx` with the queries and UI for your data product.
+- Keep `blueprint.yml` as the resource manifest that connects the Flight, share, and Dive.
+
+## Local Checks
+
+```bash
+make validate
+make render-preview __BLUEPRINT_NAME__
+make preview-smoke __BLUEPRINT_NAME__
+```

--- a/templates/blueprint/blueprint.yml
+++ b/templates/blueprint/blueprint.yml
@@ -1,7 +1,7 @@
 schemaVersion: 1
 name: __BLUEPRINT_NAME__
 title: __BLUEPRINT_NAME__
-description: Starter project that publishes a small metrics dataset and reads it from a Dive.
+description: Starter project that publishes a small daily metrics dataset and reads it from a Dive.
 
 variables:
   database:
@@ -55,7 +55,7 @@ resources:
       source: src/dive.tsx
       requiredResources:
         - share: data
-          alias: __BLUEPRINT_NAME__
+          alias: __DATABASE_NAME__
       targets:
         preview:
           title: __BLUEPRINT_NAME__:${target.branch} (Preview)

--- a/templates/blueprint/dive.tsx
+++ b/templates/blueprint/dive.tsx
@@ -1,57 +1,385 @@
 import { useSQLQuery } from "@motherduck/react-sql-query";
+import type { CSSProperties } from "react";
+import {
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+} from "recharts";
 
-export const REQUIRED_DATABASES = [{ alias: "__BLUEPRINT_NAME__", shareName: "__DATABASE_NAME__" }];
+export const REQUIRED_DATABASES = [{ alias: "__DATABASE_NAME__", shareName: "__DATABASE_NAME__" }];
+
+type SummaryRow = {
+  metric: string;
+  current_value: number | string;
+  avg_value: number | string;
+  total_value: number | string;
+  first_measured_on: string;
+  last_measured_on: string;
+  loaded_at_utc: string;
+};
+
+type DailyRow = {
+  measured_on: string;
+  metric: string;
+  value: number | string;
+};
+
+function asNumber(value: number | string | null | undefined) {
+  if (value == null) return 0;
+  return Number(value);
+}
+
+function formatNumber(value: number | string | null | undefined) {
+  return new Intl.NumberFormat("en-US").format(asNumber(value));
+}
+
+function formatCompact(value: number | string | null | undefined) {
+  return new Intl.NumberFormat("en-US", { notation: "compact" }).format(asNumber(value));
+}
+
+function formatMetricName(value: string) {
+  return value.replace(/_/g, " ");
+}
+
+function transformDaily(rows: DailyRow[]) {
+  const byDate = new Map<string, Record<string, number | string>>();
+  for (const row of rows) {
+    const current = byDate.get(row.measured_on) ?? { measured_on: row.measured_on };
+    current[row.metric] = asNumber(row.value);
+    byDate.set(row.measured_on, current);
+  }
+  return Array.from(byDate.values()).sort((left, right) =>
+    String(left.measured_on).localeCompare(String(right.measured_on)),
+  );
+}
+
+function LoadingBlock({ label }: { label: string }) {
+  return (
+    <div style={styles.loadingBlock}>
+      <span style={styles.loadingTitle}>{label}</span>
+      <span style={styles.loadingLine} />
+      <span style={{ ...styles.loadingLine, width: "64%" }} />
+    </div>
+  );
+}
+
+function ErrorBlock({ message }: { message: string }) {
+  return (
+    <div style={styles.errorBlock}>
+      <strong>Query failed</strong>
+      <span>{message}</span>
+    </div>
+  );
+}
 
 export default function BlueprintDive() {
-  const metrics = useSQLQuery(`
-    SELECT metric, value, loaded_at_utc
-    FROM "__BLUEPRINT_NAME__"."main"."starter_metrics"
-    ORDER BY metric
+  const summaryQuery = useSQLQuery<SummaryRow[]>(`
+    SELECT
+      metric,
+      current_value,
+      avg_value,
+      total_value,
+      first_measured_on::VARCHAR AS first_measured_on,
+      last_measured_on::VARCHAR AS last_measured_on,
+      loaded_at_utc::VARCHAR AS loaded_at_utc
+    FROM "__DATABASE_NAME__"."main"."starter_metric_summary"
+    ORDER BY current_value DESC
   `);
 
-  const rows = (metrics.data ?? []) as Array<{
-    metric: string;
-    value: number;
-    loaded_at_utc: string;
-  }>;
+  const dailyQuery = useSQLQuery<DailyRow[]>(`
+    SELECT
+      measured_on::VARCHAR AS measured_on,
+      metric,
+      value
+    FROM "__DATABASE_NAME__"."main"."starter_daily_metrics"
+    ORDER BY measured_on, metric
+  `);
+
+  const summary = summaryQuery.data ?? [];
+  const daily = dailyQuery.data ?? [];
+  const trend = transformDaily(daily);
+  const metrics = summary.map((row) => row.metric);
+  const latestLoad = summary[0]?.loaded_at_utc ?? "Pending";
 
   return (
-    <main style={{ fontFamily: "system-ui, sans-serif", padding: 32, maxWidth: 760 }}>
-      <p style={{ color: "#5f6b7a", margin: 0 }}>MotherDuck blueprint starter</p>
-      <h1 style={{ margin: "8px 0 24px" }}>__BLUEPRINT_NAME__</h1>
-      {metrics.isLoading ? (
-        <p>Loading metrics...</p>
-      ) : metrics.isError ? (
-        <p>Unable to load metrics.</p>
+    <main style={styles.page}>
+      <header style={styles.header}>
+        <div>
+          <p style={styles.eyebrow}>MotherDuck blueprint starter</p>
+          <h1 style={styles.title}>__BLUEPRINT_NAME__</h1>
+          <p style={styles.subtitle}>
+            Daily starter metrics loaded by the project Flight and published through the project share.
+          </p>
+        </div>
+        <div style={styles.loadBadge}>
+          <span style={styles.loadLabel}>Last load</span>
+          <span>{latestLoad}</span>
+        </div>
+      </header>
+
+      {summaryQuery.error ? <ErrorBlock message={summaryQuery.error.message} /> : null}
+      {dailyQuery.error ? <ErrorBlock message={dailyQuery.error.message} /> : null}
+
+      {summaryQuery.isLoading ? (
+        <LoadingBlock label="Loading metric summary" />
       ) : (
-        <table style={{ borderCollapse: "collapse", width: "100%" }}>
-          <thead>
-            <tr>
-              <th style={headerStyle}>Metric</th>
-              <th style={headerStyle}>Value</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((row) => (
-              <tr key={row.metric}>
-                <td style={cellStyle}>{row.metric}</td>
-                <td style={cellStyle}>{Number(row.value).toLocaleString()}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <section style={styles.kpiGrid}>
+          {summary.map((row) => (
+            <article key={row.metric} style={styles.kpiCard}>
+              <span style={styles.kpiLabel}>{formatMetricName(row.metric)}</span>
+              <strong style={styles.kpiValue}>{formatCompact(row.current_value)}</strong>
+              <span style={styles.kpiMeta}>avg {formatNumber(Math.round(asNumber(row.avg_value)))}</span>
+            </article>
+          ))}
+        </section>
       )}
+
+      <section style={styles.panel}>
+        <div style={styles.panelHeader}>
+          <h2 style={styles.panelTitle}>Daily metric trend</h2>
+        </div>
+        {dailyQuery.isLoading ? (
+          <LoadingBlock label="Loading daily trend" />
+        ) : (
+          <div style={styles.chart}>
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={trend} margin={{ top: 12, right: 24, bottom: 0, left: 0 }}>
+                <CartesianGrid stroke="#e5e7eb" vertical={false} />
+                <XAxis dataKey="measured_on" minTickGap={24} tick={{ fontSize: 11 }} />
+                <YAxis tickFormatter={formatCompact} tick={{ fontSize: 11 }} width={56} />
+                <Tooltip formatter={(value) => formatNumber(value as number)} />
+                {metrics.map((metric, index) => (
+                  <Line
+                    key={metric}
+                    type="monotone"
+                    dataKey={metric}
+                    name={formatMetricName(metric)}
+                    stroke={palette[index % palette.length]}
+                    dot={false}
+                    strokeWidth={2}
+                  />
+                ))}
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </section>
+
+      <section style={styles.panel}>
+        <div style={styles.panelHeader}>
+          <h2 style={styles.panelTitle}>Metric summary</h2>
+        </div>
+        {summaryQuery.isLoading ? (
+          <LoadingBlock label="Loading summary table" />
+        ) : (
+          <div style={styles.tableWrap}>
+            <table style={styles.table}>
+              <thead>
+                <tr>
+                  <th style={styles.th}>Metric</th>
+                  <th style={styles.thRight}>Current</th>
+                  <th style={styles.thRight}>Average</th>
+                  <th style={styles.thRight}>Total</th>
+                  <th style={styles.th}>Range</th>
+                </tr>
+              </thead>
+              <tbody>
+                {summary.map((row) => (
+                  <tr key={row.metric}>
+                    <td style={styles.tdStrong}>{formatMetricName(row.metric)}</td>
+                    <td style={styles.tdRight}>{formatNumber(row.current_value)}</td>
+                    <td style={styles.tdRight}>{formatNumber(Math.round(asNumber(row.avg_value)))}</td>
+                    <td style={styles.tdRight}>{formatNumber(row.total_value)}</td>
+                    <td style={styles.td}>{row.first_measured_on} to {row.last_measured_on}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
     </main>
   );
 }
 
-const headerStyle = {
-  textAlign: "left",
-  borderBottom: "1px solid #d9dee7",
-  padding: "10px 8px",
-} as const;
+const palette = ["#2563eb", "#059669", "#dc2626", "#7c3aed"];
 
-const cellStyle = {
-  borderBottom: "1px solid #eef1f5",
-  padding: "10px 8px",
-} as const;
+const styles: Record<string, CSSProperties> = {
+  page: {
+    minHeight: "100vh",
+    padding: "28px",
+    background: "#f6f7f9",
+    color: "#111827",
+    fontFamily: "Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
+  },
+  header: {
+    display: "flex",
+    flexWrap: "wrap",
+    justifyContent: "space-between",
+    alignItems: "flex-end",
+    gap: "20px",
+    marginBottom: "22px",
+  },
+  eyebrow: {
+    margin: "0 0 8px",
+    color: "#2563eb",
+    fontSize: "12px",
+    fontWeight: 700,
+    textTransform: "uppercase",
+  },
+  title: {
+    margin: 0,
+    fontSize: "32px",
+    lineHeight: 1.1,
+  },
+  subtitle: {
+    maxWidth: "720px",
+    margin: "10px 0 0",
+    color: "#4b5563",
+    fontSize: "15px",
+    lineHeight: 1.5,
+  },
+  loadBadge: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "4px",
+    minWidth: "220px",
+    color: "#374151",
+    fontSize: "13px",
+    textAlign: "right",
+  },
+  loadLabel: {
+    color: "#6b7280",
+    fontSize: "12px",
+    fontWeight: 700,
+    textTransform: "uppercase",
+  },
+  kpiGrid: {
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+    gap: "12px",
+    marginBottom: "16px",
+  },
+  kpiCard: {
+    minHeight: "96px",
+    padding: "16px",
+    border: "1px solid #e5e7eb",
+    borderRadius: "8px",
+    background: "#ffffff",
+  },
+  kpiLabel: {
+    display: "block",
+    marginBottom: "8px",
+    color: "#6b7280",
+    fontSize: "12px",
+    fontWeight: 700,
+    textTransform: "uppercase",
+  },
+  kpiValue: {
+    display: "block",
+    fontSize: "28px",
+    lineHeight: 1,
+  },
+  kpiMeta: {
+    display: "block",
+    marginTop: "10px",
+    color: "#6b7280",
+    fontSize: "12px",
+  },
+  panel: {
+    marginBottom: "16px",
+    padding: "16px",
+    border: "1px solid #e5e7eb",
+    borderRadius: "8px",
+    background: "#ffffff",
+  },
+  panelHeader: {
+    marginBottom: "12px",
+  },
+  panelTitle: {
+    margin: 0,
+    fontSize: "16px",
+  },
+  chart: {
+    width: "100%",
+    height: "340px",
+  },
+  tableWrap: {
+    overflowX: "auto",
+  },
+  table: {
+    width: "100%",
+    borderCollapse: "collapse",
+    fontSize: "13px",
+  },
+  th: {
+    padding: "10px 8px",
+    borderBottom: "1px solid #e5e7eb",
+    color: "#6b7280",
+    textAlign: "left",
+    whiteSpace: "nowrap",
+  },
+  thRight: {
+    padding: "10px 8px",
+    borderBottom: "1px solid #e5e7eb",
+    color: "#6b7280",
+    textAlign: "right",
+    whiteSpace: "nowrap",
+  },
+  td: {
+    padding: "12px 8px",
+    borderBottom: "1px solid #f1f5f9",
+    whiteSpace: "nowrap",
+  },
+  tdStrong: {
+    padding: "12px 8px",
+    borderBottom: "1px solid #f1f5f9",
+    fontWeight: 700,
+    textTransform: "capitalize",
+  },
+  tdRight: {
+    padding: "12px 8px",
+    borderBottom: "1px solid #f1f5f9",
+    textAlign: "right",
+    whiteSpace: "nowrap",
+  },
+  loadingBlock: {
+    minHeight: "144px",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    gap: "12px",
+    marginBottom: "16px",
+    padding: "16px",
+    border: "1px solid #e5e7eb",
+    borderRadius: "8px",
+    background: "#ffffff",
+    color: "#6b7280",
+  },
+  loadingTitle: {
+    fontSize: "13px",
+    fontWeight: 700,
+  },
+  loadingLine: {
+    width: "84%",
+    height: "12px",
+    borderRadius: "999px",
+    background: "#e5e7eb",
+  },
+  errorBlock: {
+    display: "flex",
+    gap: "12px",
+    alignItems: "center",
+    marginBottom: "16px",
+    padding: "12px 14px",
+    border: "1px solid #fecaca",
+    borderRadius: "8px",
+    background: "#fef2f2",
+    color: "#991b1b",
+    fontSize: "13px",
+  },
+};

--- a/templates/blueprint/flight.py
+++ b/templates/blueprint/flight.py
@@ -1,7 +1,7 @@
 """Starter Flight for the __BLUEPRINT_NAME__ blueprint.
 
-This creates a tiny project-owned database, publishes it as a share, and gives
-the starter Dive something real to query.
+This creates a project-owned database with daily metrics, publishes it as a
+share, and gives the starter Dive something real to query.
 """
 
 from __future__ import annotations
@@ -71,25 +71,45 @@ def load_starter_data(con: duckdb.DuckDBPyConnection, database: str, schema: str
     con.execute(f"CREATE SCHEMA IF NOT EXISTS {schema_ident}")
     con.execute(
         f"""
-        CREATE OR REPLACE TABLE {schema_ident}.starter_metrics AS
-        SELECT *
-        FROM (
+        CREATE OR REPLACE TABLE {schema_ident}.starter_daily_metrics AS
+        WITH days AS (
+          SELECT
+            (current_date - (13 - day_index)::INTEGER)::DATE AS measured_on,
+            day_index
+          FROM range(14) AS days(day_index)
+        ),
+        metric_seed(metric, base_value, daily_step) AS (
           VALUES
-            ('active_accounts', 128, ?),
-            ('monthly_queries', 8421, ?),
-            ('shared_databases', 7, ?)
-        ) AS metrics(metric, value, loaded_at_utc)
+            ('active_accounts', 118, 2),
+            ('daily_queries', 3910, 185),
+            ('shared_databases', 4, 1)
+        )
+        SELECT
+          metric,
+          measured_on,
+          (base_value + day_index * daily_step)::BIGINT AS value,
+          ? AS loaded_at_utc
+        FROM days
+        CROSS JOIN metric_seed
+        ORDER BY measured_on, metric
         """,
-        [loaded_at, loaded_at, loaded_at],
+        [loaded_at],
     )
     con.execute(
         f"""
-        CREATE OR REPLACE VIEW {schema_ident}.starter_summary AS
+        CREATE OR REPLACE VIEW {schema_ident}.starter_metric_summary AS
         SELECT
-          count(*)::BIGINT AS metric_count,
+          metric,
+          arg_max(value, measured_on)::BIGINT AS current_value,
+          min(value)::BIGINT AS min_value,
+          max(value)::BIGINT AS max_value,
+          round(avg(value), 2)::DOUBLE AS avg_value,
           sum(value)::BIGINT AS total_value,
+          min(measured_on) AS first_measured_on,
+          max(measured_on) AS last_measured_on,
           max(loaded_at_utc) AS loaded_at_utc
-        FROM {schema_ident}.starter_metrics
+        FROM {schema_ident}.starter_daily_metrics
+        GROUP BY metric
         """
     )
 
@@ -130,7 +150,7 @@ def main() -> None:
     load_starter_data(con, database, schema)
     share_url = publish_share(con, database, share)
 
-    print(f"Loaded starter metrics into md:{database}.{schema}.starter_metrics")
+    print(f"Loaded starter metrics into md:{database}.{schema}.starter_daily_metrics")
     print(f"Published share {share}: {share_url}")
 
 


### PR DESCRIPTION
This improves the generated starter blueprint so new projects start from a complete Flight, share, and Dive example, then adds CI coverage that proves the generated example can be created, validated, built, and removed.

### Codex description

- expands the starter Flight and Dive templates with daily metrics, a summary view, a README, and an underscore-safe Dive alias
- adds make example-smoke and a temp-copy scaffold smoke script that creates, renders, builds, destroys, and revalidates a generated blueprint
- adds a non-deploying CI workflow that runs validation, mock deployment tests, included Dive build, and generated-example create/destroy coverage
