### PR TITLE
feat: add deploy planning

### DIFF
--- a/.github/workflows/deploy_blueprints.yaml
+++ b/.github/workflows/deploy_blueprints.yaml
@@ -130,7 +130,9 @@ jobs:
               exit 1
             fi
           else
-            OUTPUT="$(./tools/md_blueprints deploy --target preview --branch "$PREVIEW_BRANCH" --blueprints "$BLUEPRINTS")"
+            PLAN_OUTPUT="$(./tools/md_blueprints plan --target preview --branch "$PREVIEW_BRANCH" --blueprints "$BLUEPRINTS")"
+            DEPLOY_OUTPUT="$(./tools/md_blueprints deploy --target preview --branch "$PREVIEW_BRANCH" --blueprints "$BLUEPRINTS")"
+            OUTPUT="$(printf "%s\n\n%s" "$PLAN_OUTPUT" "$DEPLOY_OUTPUT")"
           fi
           echo "comment_body<<EOF" >> "$GITHUB_OUTPUT"
           echo "$OUTPUT" >> "$GITHUB_OUTPUT"
@@ -191,4 +193,10 @@ jobs:
             echo "Production deploy skipped because MOTHERDUCK_TOKEN is not configured for this repository."
             exit 0
           fi
+          PLAN_OUTPUT="$(./tools/md_blueprints plan --target prod --blueprints "$BLUEPRINTS")"
+          {
+            echo "### Production Blueprint Plan"
+            echo
+            echo "$PLAN_OUTPUT"
+          } >> "$GITHUB_STEP_SUMMARY"
           ./tools/md_blueprints deploy --target prod --blueprints "$BLUEPRINTS"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Update this file in every pull request. Add entries under `Unreleased` until the
 - Added a complete `blueprint.yml` field reference for agents, LLM crawlers, and blueprint authors.
 - Introduced project-first blueprint packages under `blueprints/<name>/`.
 - Added the root `motherduck.yml` repository manifest, JSON schemas, and `tools/md_blueprints`.
+- Added `tools/md_blueprints plan` for read-only live deployment planning.
+- Added `tools/md_blueprints cleanup --dry-run` for preview cleanup planning.
+- Added optional target deployment metadata for service account identity labels and token env var selection.
 - Added a deployable starter scaffold through `make new-blueprint <blueprint-name>`.
 - Added manifest-driven GitHub workflows for validation, preview deploys, production deploys, and preview cleanup.
 - Added local smoke coverage for manifest validation, rendered targets, mock deploys, preview cleanup, failed Flight runs, and Dive preview builds.
@@ -22,6 +25,8 @@ Update this file in every pull request. Add entries under `Unreleased` until the
 
 - Expanded the generated starter blueprint with daily metrics, a summary view, an underscore-safe Dive alias, and a richer dashboard.
 - Migrated the Wikipedia Pageviews example into `blueprints/wikipedia-pageviews/`.
+- Ran read-only deployment plans before preview and production deploys in CI.
+- Failed deploys before mutation when live planning finds duplicate Flights or Dives.
 - Skipped production deployment and preview cleanup workflows when `MOTHERDUCK_TOKEN` is not configured.
 - Reworked setup language for self-service use in your own repository.
 - Simplified the README into a self-service quickstart and moved detailed repository mechanics into `docs/repository-reference.md`.

--- a/README.md
+++ b/README.md
@@ -52,12 +52,21 @@ make preview-smoke revenue-overview
 
 Then replace the starter Flight and Dive with your real project logic.
 
+When you have a MotherDuck token configured, inspect live create/update/delete actions before applying them:
+
+```bash
+./tools/md_blueprints plan --target preview --branch feature/example --blueprints revenue-overview
+./tools/md_blueprints cleanup --dry-run --target preview --branch feature/example --blueprints revenue-overview
+```
+
 ## Best Practices to Copy
 
 - Keep one project or data product per `blueprints/<name>/` package.
 - Use lowercase slug names such as `account-360` or `revenue-ops`.
 - Keep preview resources branch-scoped and production resources stable.
+- Run a deployment plan before live deploys and use cleanup dry-runs before deleting previews.
 - Deploy from CI with a service account token.
+- Use target `deployment` metadata when preview and production use different service accounts or token env vars.
 - Store secrets in GitHub Actions, never in the repo.
 - Update [CHANGELOG.md](CHANGELOG.md) in every pull request.
 

--- a/docs/blueprint-yml-reference.md
+++ b/docs/blueprint-yml-reference.md
@@ -331,6 +331,26 @@ Rendered preview `config`:
 }
 ```
 
+## Related Root Target Fields
+
+`blueprint.yml` target overrides are rendered against targets declared in the root `motherduck.yml`. Live commands also read optional deployment metadata from the root target:
+
+```yaml
+targets:
+  preview:
+    mode: preview
+    deployment:
+      tokenEnvVar: MOTHERDUCK_TOKEN
+      identity: GitHub Actions preview service account
+```
+
+| Path | Required | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `targets.<target>.deployment.tokenEnvVar` | No | Non-empty string | `MOTHERDUCK_TOKEN` | Environment variable that contains the MotherDuck token for live `plan`, `deploy`, and `cleanup` commands. |
+| `targets.<target>.deployment.identity` | No | Non-empty string | None | Non-secret human label for the deployment identity. |
+
+The deploy tool passes the selected token value to DuckDB as `MOTHERDUCK_TOKEN` and never prints it.
+
 ## Validation Summary
 
 Run these checks before opening a pull request:
@@ -341,4 +361,4 @@ make mock-test
 make preview-smoke <blueprint-name>
 ```
 
-`make validate` checks schemas, renders preview and production targets, enforces uniqueness, verifies file paths, parses Flight Python sources, and checks rendered resource rules. `make mock-test` exercises scaffold creation, preview deploy, production deploy, cleanup, and failed Flight run handling without contacting MotherDuck. Run `make preview-smoke <blueprint-name>` for every blueprint that includes a Dive.
+`make validate` checks schemas, renders preview and production targets, enforces uniqueness, verifies file paths, parses Flight Python sources, and checks rendered resource rules. `make mock-test` exercises scaffold creation, live-state planning, preview deploy, production deploy, cleanup dry-runs, cleanup, and failed Flight run handling without contacting MotherDuck. Run `make preview-smoke <blueprint-name>` for every blueprint that includes a Dive.

--- a/docs/examples/wikipedia-pageviews.md
+++ b/docs/examples/wikipedia-pageviews.md
@@ -36,13 +36,14 @@ On pull requests:
 
 1. `.github/workflows/deploy_blueprints.yaml` computes changed blueprint packages.
 2. `tools/md_blueprints validate` validates all manifests and rendered targets.
-3. `tools/md_blueprints deploy --target preview --branch <branch>` deploys changed blueprints.
-4. The preview Flight name and Dive title include the branch name.
-5. The preview database and share include `${target.branch_slug}`.
-6. The Flight runs once, waits for success, waits for the share URL, and deploys the Dive.
-7. A PR comment lists preview Flights, shares, and Dives.
+3. `tools/md_blueprints plan --target preview --branch <branch>` inspects live resources without mutating them.
+4. `tools/md_blueprints deploy --target preview --branch <branch>` deploys changed blueprints.
+5. The preview Flight name and Dive title include the branch name.
+6. The preview database and share include `${target.branch_slug}`.
+7. The Flight runs once, waits for success, waits for the share URL, and deploys the Dive.
+8. A PR comment lists the plan plus preview Flights, shares, and Dives.
 
-On merge to `main`, production deployment runs through the protected `motherduck-production` environment and uses stable names.
+On merge to `main`, production deployment writes a live plan to the GitHub job summary, runs through the protected `motherduck-production` environment, and uses stable names.
 
 ## Preview Behavior
 
@@ -52,7 +53,7 @@ The `preview` target disables schedules and requires cleanup-sensitive data reso
 wikipedia_pageviews_preview_feature_mock_test
 ```
 
-Preview cleanup deletes the Dive first, then the Flight, then the preview share and database. The cleanup guard refuses to drop preview data resources whose names do not include the rendered branch slug.
+Preview cleanup deletes the Dive first, then the Flight, then the preview share and database. Use `tools/md_blueprints cleanup --dry-run --target preview --branch <branch>` to inspect those actions without deleting anything. The cleanup guard refuses to drop preview data resources whose names do not include the rendered branch slug.
 
 ## Local Checks
 

--- a/docs/github-setup.md
+++ b/docs/github-setup.md
@@ -53,6 +53,8 @@ The repo includes cleanup workflows for preview blueprints. Keep those workflows
 
 Pull requests validate even when `MOTHERDUCK_TOKEN` is not configured. Preview deployment is skipped in that case; add the secret when you want PRs to create live MotherDuck previews.
 
+If a target uses a different service account secret, set `targets.<target>.deployment.tokenEnvVar` in `motherduck.yml` and expose that env var in your workflow. The default remains `MOTHERDUCK_TOKEN`.
+
 ## 5. Add Assets
 
 Add every deployable asset inside a blueprint package:
@@ -81,3 +83,9 @@ make preview-smoke <blueprint-name>
 ```
 
 Skip `make preview-smoke` only when the changed blueprint has no Dive.
+
+Live workflows run `tools/md_blueprints plan` before deploy. You can run the same check locally with a MotherDuck token:
+
+```bash
+./tools/md_blueprints plan --target preview --branch feature/example --blueprints <blueprint-name>
+```

--- a/docs/repository-reference.md
+++ b/docs/repository-reference.md
@@ -49,6 +49,19 @@ A single MotherDuck user or service account can own many databases, and one proj
 
 Prefer one deployment service account per project/environment. If a project must use multiple service accounts, model that explicitly as identity configuration for the affected target or resource instead of splitting one project into artificial packages.
 
+Target deployment metadata is optional:
+
+```yaml
+targets:
+  prod:
+    mode: production
+    deployment:
+      tokenEnvVar: MOTHERDUCK_TOKEN
+      identity: GitHub Actions production service account
+```
+
+`tokenEnvVar` defaults to `MOTHERDUCK_TOKEN`. If you set a different env var, the deploy tool reads that env var and passes its value to DuckDB as `MOTHERDUCK_TOKEN` without printing it. `identity` is a non-secret label for humans.
+
 ## Blueprint Packages
 
 Each deployable project lives under `blueprints/<name>/` and declares resources in `blueprint.yml`:
@@ -94,13 +107,19 @@ make example-smoke
 make validate
 make render-preview <blueprint-name>
 make mock-test
+./tools/md_blueprints plan --target preview --branch feature/local --blueprints <blueprint-name>
+./tools/md_blueprints cleanup --dry-run --target preview --branch feature/local --blueprints <blueprint-name>
 ```
 
 `make validate` parses `motherduck.yml`, expands included blueprints, validates against the committed schemas, renders preview and production targets, checks uniqueness, checks Flight Python syntax, and validates Dive required resources.
 
 `make preview-smoke <blueprint-name>` writes that blueprint's Dive into the local Vite preview harness and runs a production build without starting a server.
 
-`make mock-test` shadows `duckdb` with a fake CLI and exercises validation, preview deploy, production deploy, cleanup, and failed Flight run reporting without contacting MotherDuck.
+`make mock-test` shadows `duckdb` with a fake CLI and exercises validation, planning, preview deploy, production deploy, cleanup dry-runs, cleanup, and failed Flight run reporting without contacting MotherDuck.
+
+`tools/md_blueprints plan` validates and renders selected blueprints, queries live MotherDuck state with read-only SQL, and reports whether Flights and Dives will be created or updated. Shares are reported as `present` or `missing` because the deployer waits for shares but project Flight code creates them.
+
+`tools/md_blueprints cleanup --dry-run` shows the preview Dives, Flights, shares, and databases that cleanup would delete or drop. It uses the same branch-slug safety checks as real cleanup and does not issue delete or drop queries.
 
 `make example-smoke` creates a generated starter blueprint in an isolated temporary copy, validates its rendered preview target, builds its Dive, destroys the generated package, and validates the repository again.
 
@@ -117,8 +136,9 @@ make preview-smoke <blueprint-name> # when the blueprint has a Dive
 
 - The `CI` workflow validates manifests, runs mock deployment tests, builds the included example Dive, and creates then destroys a generated starter blueprint.
 - Pull requests validate all manifests, discover changed blueprint packages from `motherduck.yml`, deploy the `preview` target, and comment with preview links.
+- Preview deployment runs a read-only plan immediately before deploy; the PR comment includes the plan and deployed links.
 - Preview cleanup runs when a PR closes or a branch is deleted. Dives are deleted before Flights, shares, and preview databases.
-- Pushes to `main` deploy the `prod` target through the protected `motherduck-production` environment.
+- Pushes to `main` plan the `prod` target, write the plan to the GitHub job summary, then deploy through the protected `motherduck-production` environment.
 - No workflow file needs per-blueprint path filters or manual asset registration.
 
 ## Context Layer

--- a/docs/setup-your-repository.md
+++ b/docs/setup-your-repository.md
@@ -86,7 +86,7 @@ make mock-test
 make example-smoke
 ```
 
-`make validate` checks manifests and rendered targets. `make mock-test` shadows `duckdb` with a fake CLI and exercises preview deploy, production deploy, cleanup, and failed-run reporting without contacting MotherDuck. `make example-smoke` creates, validates, builds, and destroys a generated starter blueprint in a temporary copy of the repo.
+`make validate` checks manifests and rendered targets. `make mock-test` shadows `duckdb` with a fake CLI and exercises planning, preview deploy, production deploy, cleanup dry-runs, cleanup, and failed-run reporting without contacting MotherDuck. `make example-smoke` creates, validates, builds, and destroys a generated starter blueprint in a temporary copy of the repo.
 
 If you keep a Dive in the repo, also run a finite local preview build:
 
@@ -111,11 +111,12 @@ Expected preview flow:
 
 1. `Deploy Blueprints` validates manifests.
 2. The changed blueprint packages are discovered from `motherduck.yml`.
-3. Preview Flights deploy with schedules disabled.
-4. Preview Flights run when `runOnDeploy` is true.
-5. Preview databases and shares are created with the branch slug.
-6. Dives deploy after required shares are resolvable.
-7. A PR comment lists preview Flight, share, and Dive links.
+3. The workflow runs a read-only preview plan.
+4. Preview Flights deploy with schedules disabled.
+5. Preview Flights run when `runOnDeploy` is true.
+6. Preview databases and shares are created with the branch slug.
+7. Dives deploy after required shares are resolvable.
+8. A PR comment lists the plan plus preview Flight, share, and Dive links.
 
 ## 8. Verify Cleanup
 
@@ -130,6 +131,12 @@ Expected cleanup flow:
 
 Cleanup refuses to drop share/database names that do not include the branch slug.
 
+You can preview cleanup locally before closing a PR:
+
+```bash
+./tools/md_blueprints cleanup --dry-run --target preview --branch test/wikipedia-blueprint
+```
+
 ## 9. Deploy to Production
 
 Merge the PR to `main`.
@@ -138,10 +145,11 @@ Expected production flow:
 
 1. `Deploy Blueprints` runs on `main`.
 2. GitHub waits for approval in `motherduck-production`.
-3. Production Flights deploy.
-4. Flights run when `runOnDeploy` is true.
-5. Required shares are resolved.
-6. Production Dives deploy.
+3. The workflow writes a read-only production plan to the GitHub job summary.
+4. Production Flights deploy.
+5. Flights run when `runOnDeploy` is true.
+6. Required shares are resolved.
+7. Production Dives deploy.
 
 ## 10. Customize the Blueprints
 
@@ -151,5 +159,6 @@ You can then:
 - Replace the Wikipedia example with your own blueprint package.
 - Add standalone Dives or Flights as one-resource blueprints.
 - Add paired Flight + Dive packages that declare shared data products in `resources.shares`.
+- Add target `deployment.tokenEnvVar` and `deployment.identity` metadata in `motherduck.yml` if preview and production use different service account secrets.
 - Version context-layer assets under `context/` or package-local `resources.context` entries with `deploy: false`.
 - Update `.github/CODEOWNERS`.

--- a/motherduck.yml
+++ b/motherduck.yml
@@ -14,6 +14,9 @@ targets:
   preview:
     mode: preview
     default: true
+    deployment:
+      tokenEnvVar: MOTHERDUCK_TOKEN
+      identity: GitHub Actions preview service account
     policies:
       disableSchedules: true
       cleanup: true
@@ -24,6 +27,9 @@ targets:
   prod:
     mode: production
     environment: motherduck-production
+    deployment:
+      tokenEnvVar: MOTHERDUCK_TOKEN
+      identity: GitHub Actions production service account
     policies:
       serviceAccountRecommended: true
     variables:

--- a/schemas/motherduck-root.schema.json
+++ b/schemas/motherduck-root.schema.json
@@ -57,6 +57,14 @@
         "mode": { "type": "string", "minLength": 1 },
         "default": { "type": "boolean" },
         "environment": { "type": "string" },
+        "deployment": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "tokenEnvVar": { "type": "string", "minLength": 1 },
+            "identity": { "type": "string", "minLength": 1 }
+          }
+        },
         "variables": {
           "type": "object",
           "additionalProperties": { "$ref": "#/$defs/variable" }

--- a/scripts/mock-test.sh
+++ b/scripts/mock-test.sh
@@ -21,6 +21,7 @@ cat > "${FAKE_BIN}/duckdb" <<'MOCK_DUCKDB'
 set -euo pipefail
 
 query="$*"
+: "${MOTHERDUCK_TOKEN:?MOTHERDUCK_TOKEN is required by fake duckdb}"
 state_dir="${MOCK_DUCKDB_STATE_DIR:?MOCK_DUCKDB_STATE_DIR is required}"
 flight_state="${state_dir}/flight_id"
 run_state="${state_dir}/run_number"
@@ -31,7 +32,9 @@ run_status="${MOCK_FLIGHT_RUN_STATUS:-RUN_STATUS_SUCCEEDED}"
 echo "$query" >> "${state_dir}/queries.log"
 
 if [[ "$query" == *"MD_LIST_DATABASE_SHARES"* ]]; then
-  echo "$share_url"
+  if [[ "${MOCK_SHARE_MISSING:-false}" != "true" ]]; then
+    echo "$share_url"
+  fi
 elif [[ "$query" == *"MD_LIST_FLIGHT_RUNS"* ]]; then
   if [[ "$query" == *"COALESCE(MAX(run_number)"* ]]; then
     if [ -f "$run_state" ]; then
@@ -43,7 +46,10 @@ elif [[ "$query" == *"MD_LIST_FLIGHT_RUNS"* ]]; then
     echo "$(cat "$run_state")|${run_status}"
   fi
 elif [[ "$query" == *"MD_LIST_FLIGHTS"* ]]; then
-  if [ -f "$flight_state" ]; then
+  if [[ "${MOCK_DUPLICATE_FLIGHTS:-false}" == "true" ]]; then
+    echo "00000000-0000-0000-0000-000000000011"
+    echo "00000000-0000-0000-0000-000000000012"
+  elif [ -f "$flight_state" ]; then
     cat "$flight_state"
   fi
 elif [[ "$query" == *"MD_CREATE_FLIGHT"* ]]; then
@@ -67,7 +73,10 @@ elif [[ "$query" == *"MD_DROP_DATABASE_SHARE"* ]]; then
 elif [[ "$query" == *"DROP DATABASE IF EXISTS"* ]]; then
   exit 0
 elif [[ "$query" == *"MD_LIST_DIVES"* ]]; then
-  if [ -f "$dive_state" ]; then
+  if [[ "${MOCK_DUPLICATE_DIVES:-false}" == "true" ]]; then
+    echo "00000000-0000-0000-0000-000000000021"
+    echo "00000000-0000-0000-0000-000000000022"
+  elif [ -f "$dive_state" ]; then
     cat "$dive_state"
   fi
 elif [[ "$query" == *"MD_CREATE_DIVE"* ]]; then
@@ -91,6 +100,8 @@ export SHARE_RESOLVE_ATTEMPTS=1
 export SHARE_RESOLVE_SLEEP_SECONDS=0
 export FLIGHT_RUN_POLL_ATTEMPTS=1
 export FLIGHT_RUN_POLL_SLEEP_SECONDS=0
+export MOTHERDUCK_TOKEN=mock-token
+export TARGET_MD_TOKEN=target-mock-token
 
 cd "$REPO_ROOT"
 
@@ -129,6 +140,66 @@ echo "==> Rendering preview target"
 grep -q "wikipedia_pageviews_preview_feature_mock_test" "${TMP_DIR}/render.out"
 grep -q '"scheduleCron": ""' "${TMP_DIR}/render.out"
 
+echo "==> Planning preview target"
+: > "${TMP_DIR}/queries.log"
+./tools/md_blueprints plan --target preview --branch feature/mock-test --blueprints wikipedia-pageviews > "${TMP_DIR}/plan.out"
+grep -q "#### Deployment Plan" "${TMP_DIR}/plan.out"
+grep -q "wikipedia-pageviews:feature/mock-test (Preview).*create" "${TMP_DIR}/plan.out"
+grep -q "wikipedia_pageviews_preview_feature_mock_test.*present" "${TMP_DIR}/plan.out"
+grep -q "Wikipedia Pageviews:feature/mock-test (Preview).*create" "${TMP_DIR}/plan.out"
+if grep -Eq "MD_CREATE_|MD_UPDATE_|MD_DELETE_|MD_DROP_DATABASE_SHARE|DROP DATABASE" "${TMP_DIR}/queries.log"; then
+  echo "Plan command issued a mutating query" >&2
+  cat "${TMP_DIR}/queries.log" >&2
+  exit 1
+fi
+
+echo "==> Planning preview target as JSON"
+./tools/md_blueprints plan --target preview --branch feature/mock-test --blueprints wikipedia-pageviews --json > "${TMP_DIR}/plan.json"
+ruby -rjson -e '
+  records = JSON.parse(File.read(ARGV.fetch(0)))
+  required = %w[blueprint type key name action exists id notes]
+  abort "missing stable plan fields" unless records.all? { |row| (required - row.keys).empty? }
+  abort "missing flight create plan" unless records.any? { |row| row["type"] == "flight" && row["action"] == "create" }
+' "${TMP_DIR}/plan.json"
+
+echo "==> Planning missing share"
+MOCK_SHARE_MISSING=true ./tools/md_blueprints plan --target preview --branch feature/mock-test --blueprints wikipedia-pageviews > "${TMP_DIR}/missing-share.out"
+grep -q "wikipedia_pageviews_preview_feature_mock_test.*missing" "${TMP_DIR}/missing-share.out"
+
+echo "==> Rejecting duplicate live resources during plan"
+if MOCK_DUPLICATE_FLIGHTS=true ./tools/md_blueprints plan --target preview --branch feature/mock-test --blueprints wikipedia-pageviews > "${TMP_DIR}/duplicate-flight.out" 2>&1; then
+  echo "Duplicate Flight plan unexpectedly passed" >&2
+  exit 1
+fi
+grep -q "duplicate Flight name" "${TMP_DIR}/duplicate-flight.out"
+if MOCK_DUPLICATE_DIVES=true ./tools/md_blueprints plan --target preview --branch feature/mock-test --blueprints wikipedia-pageviews > "${TMP_DIR}/duplicate-dive.out" 2>&1; then
+  echo "Duplicate Dive plan unexpectedly passed" >&2
+  exit 1
+fi
+grep -q "duplicate Dive title" "${TMP_DIR}/duplicate-dive.out"
+: > "${TMP_DIR}/queries.log"
+if MOCK_DUPLICATE_FLIGHTS=true ./tools/md_blueprints deploy --target preview --branch feature/mock-test --blueprints wikipedia-pageviews > "${TMP_DIR}/duplicate-deploy.out" 2>&1; then
+  echo "Duplicate Flight deploy unexpectedly passed" >&2
+  exit 1
+fi
+grep -q "duplicate Flight name" "${TMP_DIR}/duplicate-deploy.out"
+if grep -Eq "MD_CREATE_|MD_UPDATE_|MD_DELETE_|MD_DROP_DATABASE_SHARE|DROP DATABASE" "${TMP_DIR}/queries.log"; then
+  echo "Duplicate-resource deploy issued a mutating query" >&2
+  cat "${TMP_DIR}/queries.log" >&2
+  exit 1
+fi
+
+echo "==> Verifying target-specific token env var"
+env -u MOTHERDUCK_TOKEN TARGET_MD_TOKEN=target-mock-token ./tools/md_blueprints plan --root tests/fixtures/simple --target preview --branch feature/token --blueprints simple-dive > "${TMP_DIR}/target-token.out"
+grep -q "Simple Dive:feature/token (Preview).*create" "${TMP_DIR}/target-token.out"
+
+echo "==> Verifying missing live token fails"
+if env -u MOTHERDUCK_TOKEN ./tools/md_blueprints plan --target preview --branch feature/mock-test --blueprints wikipedia-pageviews > "${TMP_DIR}/missing-token.out" 2>&1; then
+  echo "Missing token plan unexpectedly passed" >&2
+  exit 1
+fi
+grep -q "MOTHERDUCK_TOKEN is required to plan target preview" "${TMP_DIR}/missing-token.out"
+
 echo "==> Mock deploying preview blueprint"
 ./tools/md_blueprints deploy --target preview --branch feature/mock-test --blueprints wikipedia-pageviews > "${TMP_DIR}/preview.out"
 grep -q "#### Wikipedia Pageviews" "${TMP_DIR}/preview.out"
@@ -142,6 +213,19 @@ echo "==> Mock deploying production blueprint"
 echo "==> Verifying empty access token is not sent"
 if grep -q "\"access_token_name\" => ''" "${TMP_DIR}/queries.log"; then
   echo "Empty access_token_name argument was sent to MotherDuck" >&2
+  exit 1
+fi
+
+echo "==> Dry-running preview cleanup"
+: > "${TMP_DIR}/queries.log"
+./tools/md_blueprints cleanup --dry-run --target preview --branch feature/mock-test --blueprints wikipedia-pageviews > "${TMP_DIR}/cleanup-dry-run.out"
+grep -q "Wikipedia Pageviews:feature/mock-test (Preview).*delete" "${TMP_DIR}/cleanup-dry-run.out"
+grep -q "wikipedia-pageviews:feature/mock-test (Preview).*delete" "${TMP_DIR}/cleanup-dry-run.out"
+grep -q "wikipedia_pageviews_preview_feature_mock_test.*drop_share" "${TMP_DIR}/cleanup-dry-run.out"
+grep -q "wikipedia_pageviews_preview_feature_mock_test.*drop_database" "${TMP_DIR}/cleanup-dry-run.out"
+if grep -Eq "MD_CREATE_|MD_UPDATE_|MD_DELETE_|MD_DROP_DATABASE_SHARE|DROP DATABASE" "${TMP_DIR}/queries.log"; then
+  echo "Cleanup dry-run issued a mutating query" >&2
+  cat "${TMP_DIR}/queries.log" >&2
   exit 1
 fi
 

--- a/tests/fixtures/simple/motherduck.yml
+++ b/tests/fixtures/simple/motherduck.yml
@@ -10,6 +10,9 @@ targets:
   preview:
     mode: preview
     default: true
+    deployment:
+      tokenEnvVar: TARGET_MD_TOKEN
+      identity: fixture preview service account
     policies:
       disableSchedules: true
       cleanup: true

--- a/tools/md_blueprints
+++ b/tools/md_blueprints
@@ -65,8 +65,12 @@ module MDBlueprints
       %("#{value}")
     end
 
-    def run_command(*argv, stdin_data: nil)
-      stdout, stderr, status = Open3.capture3(*argv, stdin_data: stdin_data)
+    def run_command(*argv, stdin_data: nil, env: nil)
+      stdout, stderr, status = if env
+                                  Open3.capture3(env, *argv, stdin_data: stdin_data)
+                                else
+                                  Open3.capture3(*argv, stdin_data: stdin_data)
+                                end
       return stdout if status.success?
 
       raise CommandError, "#{argv.join(' ')} failed: #{stderr.strip}"
@@ -219,6 +223,59 @@ module MDBlueprints
 
   Blueprint = Struct.new(:name, :title, :path, :dir, :raw, keyword_init: true)
   RenderedBlueprint = Struct.new(:name, :title, :description, :shares, :flights, :dives, :contexts, keyword_init: true)
+  PlanRecord = Struct.new(:blueprint, :type, :key, :name, :action, :exists, :id, :notes, keyword_init: true) do
+    def to_h
+      {
+        blueprint: blueprint,
+        type: type,
+        key: key,
+        name: name,
+        action: action,
+        exists: exists,
+        id: id,
+        notes: notes.to_s
+      }
+    end
+  end
+
+  module PlanFormatter
+    module_function
+
+    def format(records, title:)
+      return "#### #{title}\n\nNo resources selected." if records.empty?
+
+      rows = records.map do |record|
+        [
+          record.blueprint,
+          record.type,
+          record.key,
+          record.name,
+          record.action,
+          format_exists(record.exists),
+          record.id,
+          record.notes
+        ].map { |value| escape_cell(value) }
+      end
+
+      lines = []
+      lines << "#### #{title}"
+      lines << ""
+      lines << "| Blueprint | Type | Key | Name | Action | Exists | ID | Notes |"
+      lines << "| --- | --- | --- | --- | --- | --- | --- | --- |"
+      rows.each { |row| lines << "| #{row.join(' | ')} |" }
+      lines.join("\n")
+    end
+
+    def format_exists(value)
+      return "" if value.nil?
+
+      value ? "yes" : "no"
+    end
+
+    def escape_cell(value)
+      value.to_s.gsub("|", "\\|").gsub(/\s+/, " ").strip
+    end
+  end
 
   class Project
     attr_reader :root, :manifest, :blueprints
@@ -285,6 +342,10 @@ module MDBlueprints
       all_names
     end
 
+    def target_config(target)
+      @manifest.fetch("targets").fetch(target) { raise ValidationError, "Unknown target #{target}" }
+    end
+
     private
 
     def load_blueprints
@@ -309,7 +370,7 @@ module MDBlueprints
     end
 
     def render_blueprint(blueprint, target, branch: nil)
-      target_config = @manifest.fetch("targets").fetch(target) { raise ValidationError, "Unknown target #{target}" }
+      target_settings = target_config(target)
       if target == "preview" && branch.to_s.empty?
         raise ValidationError, "Preview target requires --branch"
       end
@@ -327,7 +388,7 @@ module MDBlueprints
 
       raw_variables = {}
       raw_variables.merge!(extract_variable_values(@manifest["variables"] || {}))
-      raw_variables.merge!(extract_variable_values(target_config["variables"] || {}))
+      raw_variables.merge!(extract_variable_values(target_settings["variables"] || {}))
       raw_variables.merge!(extract_variable_values(blueprint.raw["variables"] || {}))
       raw_variables.merge!(extract_variable_values(blueprint.raw.dig("targets", target, "variables") || {}))
       context["var"] = render_variables(raw_variables, context)
@@ -343,7 +404,7 @@ module MDBlueprints
       flights = render_resources(resources["flights"] || {}, target, context).transform_values do |flight|
         flight["sourcePath"] = absolute_resource_path(blueprint.dir, flight.fetch("source"))
         flight["requirementsPath"] = absolute_resource_path(blueprint.dir, flight.fetch("requirements"))
-        if target_config.dig("policies", "disableSchedules") == true && target == "preview"
+        if target_settings.dig("policies", "disableSchedules") == true && target == "preview"
           flight["scheduleCron"] = ""
         end
         flight["config"] = stringify_map(flight["config"] || {})
@@ -494,30 +555,240 @@ module MDBlueprints
   class Deployer
     def initialize(project)
       @project = project
+      @sql_env = nil
+    end
+
+    def plan(target:, branch:, names:)
+      rendered = validate_and_render(target, branch, names)
+      prepare_live_command!(target, "plan")
+      build_deploy_plan(rendered)
     end
 
     def deploy(target:, branch:, names:)
-      @project.validate!(targets: [target])
-      rendered = @project.render_all(target, branch: branch, names: names)
+      rendered = validate_and_render(target, branch, names)
+      prepare_live_command!(target, "deploy")
+      records = build_deploy_plan(rendered)
+      ensure_plan_succeeds!(records)
+      plan_index = index_by_resource(records)
+
       rendered.each do |blueprint|
-        deploy_blueprint(blueprint, target)
+        deploy_blueprint(blueprint, target, plan_index)
       end
     end
 
-    def cleanup(target:, branch:, names:)
+    def cleanup_plan(target:, branch:, names:)
       raise ValidationError, "cleanup is only supported for preview target" unless target == "preview"
 
-      @project.validate!(targets: [target])
+      rendered = validate_and_render(target, branch, names)
+      prepare_live_command!(target, "cleanup")
       branch_slug = Util.branch_slug(branch)
-      rendered = @project.render_all(target, branch: branch, names: names)
-      rendered.each do |blueprint|
-        cleanup_blueprint(blueprint, branch_slug)
-      end
+      build_cleanup_plan(rendered, branch_slug)
+    end
+
+    def cleanup(target:, branch:, names:)
+      records = cleanup_plan(target: target, branch: branch, names: names)
+      ensure_plan_succeeds!(records)
+      apply_cleanup_plan(records)
+    end
+
+    def ensure_plan_succeeds!(records)
+      errors = records.select { |record| record.action == "error" }
+      return if errors.empty?
+
+      details = errors.map { |record| "#{record.blueprint}.#{record.type}.#{record.key}: #{record.notes}" }.join("; ")
+      raise ValidationError, "Plan contains errors: #{details}"
     end
 
     private
 
-    def deploy_blueprint(blueprint, target)
+    def validate_and_render(target, branch, names)
+      @project.validate!(targets: [target])
+      @project.render_all(target, branch: branch, names: names)
+    end
+
+    def prepare_live_command!(target, operation)
+      deployment = @project.target_config(target).fetch("deployment", {})
+      token_env_var = deployment.fetch("tokenEnvVar", "MOTHERDUCK_TOKEN")
+      token = ENV[token_env_var].to_s
+      if token.empty?
+        raise ValidationError, "#{token_env_var} is required to #{operation} target #{target}"
+      end
+
+      @sql_env = { "MOTHERDUCK_TOKEN" => token }
+    end
+
+    def build_deploy_plan(rendered)
+      records = []
+
+      rendered.each do |blueprint|
+        blueprint.flights.each do |key, flight|
+          ids = list_flight_ids(flight.fetch("name"))
+          records << existing_resource_record(
+            blueprint: blueprint,
+            type: "flight",
+            key: key,
+            name: flight.fetch("name"),
+            ids: ids,
+            duplicate_note: "duplicate Flight name; expected 0 or 1"
+          )
+        end
+
+        blueprint.shares.each do |key, share|
+          url = find_share_url(share.fetch("name"))
+          records << PlanRecord.new(
+            blueprint: blueprint.name,
+            type: "share",
+            key: key,
+            name: share.fetch("name"),
+            action: url.empty? ? "missing" : "present",
+            exists: !url.empty?,
+            id: url.empty? ? nil : url,
+            notes: "produced by Flight/project code; deployer waits for the share URL before dependent Dives"
+          )
+        end
+
+        blueprint.dives.each do |key, dive|
+          ids = list_dive_ids(dive.fetch("title"))
+          records << existing_resource_record(
+            blueprint: blueprint,
+            type: "dive",
+            key: key,
+            name: dive.fetch("title"),
+            ids: ids,
+            duplicate_note: "duplicate Dive title; expected 0 or 1"
+          )
+        end
+
+        blueprint.contexts.each do |key, ctx|
+          records << PlanRecord.new(
+            blueprint: blueprint.name,
+            type: "context",
+            key: key,
+            name: File.basename(ctx.fetch("sourcePath")),
+            action: "validated_only",
+            exists: false,
+            id: nil,
+            notes: "context deployment is not available yet"
+          )
+        end
+      end
+
+      records
+    end
+
+    def build_cleanup_plan(rendered, branch_slug)
+      records = []
+
+      rendered.each do |blueprint|
+        blueprint.dives.each do |key, dive|
+          title = dive.fetch("title")
+          ids = list_dive_ids(title)
+          if ids.empty?
+            records << cleanup_record(blueprint, "dive", key, title, "missing", false, nil)
+          else
+            ids.each { |id| records << cleanup_record(blueprint, "dive", key, title, "delete", true, id) }
+          end
+        end
+
+        blueprint.flights.each do |key, flight|
+          name = flight.fetch("name")
+          ids = list_flight_ids(name)
+          if ids.empty?
+            records << cleanup_record(blueprint, "flight", key, name, "missing", false, nil)
+          else
+            ids.each { |id| records << cleanup_record(blueprint, "flight", key, name, "delete", true, id) }
+          end
+        end
+
+        blueprint.shares.each do |key, share|
+          next unless share.fetch("cleanup", true)
+
+          share_name = share.fetch("name")
+          database_name = share.fetch("database")
+          unless share_name.include?(branch_slug)
+            records << cleanup_record(
+              blueprint,
+              "share",
+              key,
+              share_name,
+              "error",
+              nil,
+              nil,
+              "refusing to drop preview share without branch slug #{branch_slug}"
+            )
+            next
+          end
+
+          share_url = find_share_url(share_name)
+          if share_url.empty?
+            records << cleanup_record(blueprint, "share", key, share_name, "missing", false, nil)
+          else
+            records << cleanup_record(blueprint, "share", key, share_name, "drop_share", true, share_url)
+          end
+
+          next unless share.fetch("dropDatabase", false)
+
+          unless database_name.include?(branch_slug)
+            records << cleanup_record(
+              blueprint,
+              "database",
+              key,
+              database_name,
+              "error",
+              nil,
+              nil,
+              "refusing to drop preview database without branch slug #{branch_slug}"
+            )
+            next
+          end
+
+          records << cleanup_record(
+            blueprint,
+            "database",
+            key,
+            database_name,
+            "drop_database",
+            true,
+            nil,
+            "database existence is not inspected; cleanup uses DROP DATABASE IF EXISTS"
+          )
+        end
+      end
+
+      records
+    end
+
+    def existing_resource_record(blueprint:, type:, key:, name:, ids:, duplicate_note:)
+      case ids.length
+      when 0
+        PlanRecord.new(blueprint: blueprint.name, type: type, key: key, name: name, action: "create", exists: false, id: nil, notes: "")
+      when 1
+        PlanRecord.new(blueprint: blueprint.name, type: type, key: key, name: name, action: "update", exists: true, id: ids.first, notes: "")
+      else
+        PlanRecord.new(blueprint: blueprint.name, type: type, key: key, name: name, action: "error", exists: true, id: ids.join(","), notes: duplicate_note)
+      end
+    end
+
+    def cleanup_record(blueprint, type, key, name, action, exists, id, notes = "")
+      PlanRecord.new(
+        blueprint: blueprint.name,
+        type: type,
+        key: key,
+        name: name,
+        action: action,
+        exists: exists,
+        id: id,
+        notes: notes
+      )
+    end
+
+    def index_by_resource(records)
+      records.each_with_object({}) do |record, index|
+        index[[record.blueprint, record.type, record.key]] ||= record
+      end
+    end
+
+    def deploy_blueprint(blueprint, target, plan_index)
       $stderr.puts "Deploying blueprint '#{blueprint.name}' to #{target}..."
       flight_rows = []
       share_rows = []
@@ -525,7 +796,7 @@ module MDBlueprints
 
       blueprint.flights.each do |key, flight|
         $stderr.puts "Deploying Flight #{blueprint.name}.#{key}..."
-        flight_rows << deploy_flight(flight, target)
+        flight_rows << deploy_flight(flight, target, plan_index.fetch([blueprint.name, "flight", key]))
       end
 
       blueprint.shares.each do |_key, share|
@@ -535,7 +806,7 @@ module MDBlueprints
 
       blueprint.dives.each do |key, dive|
         $stderr.puts "Deploying Dive #{blueprint.name}.#{key}..."
-        dive_rows << deploy_dive(dive, blueprint.shares, target)
+        dive_rows << deploy_dive(dive, blueprint.shares, target, plan_index.fetch([blueprint.name, "dive", key]))
       end
 
       return unless target == "preview"
@@ -558,10 +829,9 @@ module MDBlueprints
       puts
     end
 
-    def deploy_flight(flight, target)
+    def deploy_flight(flight, target, plan)
       name = flight.fetch("name")
       name_sql = Util.sql_string(name)
-      existing_ids = sql(%(SELECT flight_id FROM MD_LIST_FLIGHTS("offset" => 0::UINTEGER, "limit" => 1000::UINTEGER) WHERE flight_name = #{name_sql})).lines.map(&:strip).reject(&:empty?)
       config_sql = Util.sql_map(flight.fetch("config", {}))
       source_sql = "(SELECT content FROM read_text(#{Util.sql_string(flight.fetch("sourcePath"))}))"
       requirements_sql = "(SELECT content FROM read_text(#{Util.sql_string(flight.fetch("requirementsPath"))}))"
@@ -577,17 +847,20 @@ module MDBlueprints
       common_args.insert(3, %("access_token_name" => #{Util.sql_string(access_token_name)})) unless access_token_name.empty?
       common_args = common_args.join(", ")
 
-      flight_id = case existing_ids.length
-                  when 0
+      flight_id = case plan.action
+                  when "create"
                     $stderr.puts "  Creating new flight '#{name}'..."
                     sql(%(SET VARIABLE source_code = #{source_sql}; SET VARIABLE requirements_txt = #{requirements_sql}; FROM MD_CREATE_FLIGHT(#{common_args});))
-                    sql(%(SELECT flight_id FROM MD_LIST_FLIGHTS("offset" => 0::UINTEGER, "limit" => 1000::UINTEGER) WHERE flight_name = #{name_sql})).strip
-                  when 1
-                    $stderr.puts "  Updating existing flight '#{name}' (#{existing_ids.first})..."
-                    sql(%(SET VARIABLE source_code = #{source_sql}; SET VARIABLE requirements_txt = #{requirements_sql}; FROM MD_UPDATE_FLIGHT("flight_id" => '#{existing_ids.first}'::UUID, #{common_args});))
-                    existing_ids.first
+                    ids = list_flight_ids(name)
+                    raise CommandError, "Expected one Flight named #{name} after create, found #{ids.length}" unless ids.length == 1
+
+                    ids.first
+                  when "update"
+                    $stderr.puts "  Updating existing flight '#{name}' (#{plan.id})..."
+                    sql(%(SET VARIABLE source_code = #{source_sql}; SET VARIABLE requirements_txt = #{requirements_sql}; FROM MD_UPDATE_FLIGHT("flight_id" => '#{plan.id}'::UUID, #{common_args});))
+                    plan.id
                   else
-                    raise ValidationError, "Found #{existing_ids.length} flights named #{name}; expected 0 or 1"
+                    raise ValidationError, "Cannot deploy Flight #{name} with plan action #{plan.action}"
                   end
 
       run_started = false
@@ -638,24 +911,23 @@ module MDBlueprints
       raise CommandError, "Timed out waiting for share '#{share_name}'"
     end
 
-    def deploy_dive(dive, shares, target)
+    def deploy_dive(dive, shares, target, plan)
       title = dive.fetch("title")
       required_resources_sql = required_resources_sql(dive.fetch("requiredResources"), shares)
       content_sql = "(SELECT regexp_replace(content, 'export const REQUIRED_DATABASES[^\\n]*\\n', '', 'g') FROM read_text(#{Util.sql_string(dive.fetch("sourcePath"))}))"
       title_sql = Util.sql_string(title)
       description_sql = Util.sql_string(dive.fetch("description", ""))
-      existing_ids = sql(%(SELECT id FROM MD_LIST_DIVES() WHERE title = #{title_sql})).lines.map(&:strip).reject(&:empty?)
 
-      dive_id = case existing_ids.length
-                when 0
+      dive_id = case plan.action
+                when "create"
                   $stderr.puts "  Creating new dive '#{title}'..."
                   sql(%(SET VARIABLE content = #{content_sql}; SELECT id FROM MD_CREATE_DIVE(title = #{title_sql}, content = getvariable('content'), description = #{description_sql}, api_version = 1, required_resources = #{required_resources_sql}))).strip
-                when 1
-                  $stderr.puts "  Updating existing dive '#{title}' (#{existing_ids.first})..."
-                  sql(%(SET VARIABLE content = #{content_sql}; FROM MD_UPDATE_DIVE_CONTENT(id = '#{existing_ids.first}'::UUID, content = getvariable('content'), api_version = 1, required_resources = #{required_resources_sql}); FROM MD_UPDATE_DIVE_METADATA(id = '#{existing_ids.first}'::UUID, title = #{title_sql}, description = #{description_sql});))
-                  existing_ids.first
+                when "update"
+                  $stderr.puts "  Updating existing dive '#{title}' (#{plan.id})..."
+                  sql(%(SET VARIABLE content = #{content_sql}; FROM MD_UPDATE_DIVE_CONTENT(id = '#{plan.id}'::UUID, content = getvariable('content'), api_version = 1, required_resources = #{required_resources_sql}); FROM MD_UPDATE_DIVE_METADATA(id = '#{plan.id}'::UUID, title = #{title_sql}, description = #{description_sql});))
+                  plan.id
                 else
-                  raise ValidationError, "Found #{existing_ids.length} dives titled #{title}; expected 0 or 1"
+                  raise ValidationError, "Cannot deploy Dive #{title} with plan action #{plan.action}"
                 end
 
       $stderr.puts "  Deployed: https://app.motherduck.com/dives/#{dive_id}"
@@ -674,63 +946,47 @@ module MDBlueprints
       "[#{expressions.join(', ')}]"
     end
 
-    def cleanup_blueprint(blueprint, branch_slug)
-      $stderr.puts "Cleaning preview blueprint '#{blueprint.name}'..."
-
-      blueprint.dives.each_value do |dive|
-        title = dive.fetch("title")
-        ids = sql(%(SELECT id FROM MD_LIST_DIVES() WHERE title = #{Util.sql_string(title)})).lines.map(&:strip).reject(&:empty?)
-        if ids.empty?
-          puts "No preview Dive found for '#{title}'"
-        else
-          ids.each do |id|
-            puts "Deleting preview Dive #{id} (#{title})"
-            sql(%(FROM MD_DELETE_DIVE(id='#{id}'::UUID)))
-          end
+    def apply_cleanup_plan(records)
+      records.each do |record|
+        case [record.type, record.action]
+        when ["dive", "missing"]
+          puts "No preview Dive found for '#{record.name}'"
+        when ["dive", "delete"]
+          puts "Deleting preview Dive #{record.id} (#{record.name})"
+          sql(%(FROM MD_DELETE_DIVE(id='#{record.id}'::UUID)))
+        when ["flight", "missing"]
+          puts "No preview Flight found for '#{record.name}'"
+        when ["flight", "delete"]
+          puts "Deleting preview Flight #{record.id} (#{record.name})"
+          sql(%(FROM MD_DELETE_FLIGHT('#{record.id}'::UUID);))
+        when ["share", "missing"]
+          puts "No preview share found for '#{record.name}'"
+        when ["share", "drop_share"]
+          puts "Dropping preview share #{record.name}"
+          sql(%(FROM MD_DROP_DATABASE_SHARE(#{Util.sql_string(record.name)});))
+        when ["database", "drop_database"]
+          puts "Dropping preview database #{record.name}"
+          sql(%(DROP DATABASE IF EXISTS #{Util.quote_ident(record.name)};))
         end
-      end
-
-      blueprint.flights.each_value do |flight|
-        name = flight.fetch("name")
-        ids = sql(%(SELECT flight_id FROM MD_LIST_FLIGHTS("offset" => 0::UINTEGER, "limit" => 1000::UINTEGER) WHERE flight_name = #{Util.sql_string(name)})).lines.map(&:strip).reject(&:empty?)
-        if ids.empty?
-          puts "No preview Flight found for '#{name}'"
-        else
-          ids.each do |id|
-            puts "Deleting preview Flight #{id} (#{name})"
-            sql(%(FROM MD_DELETE_FLIGHT('#{id}'::UUID);))
-          end
-        end
-      end
-
-      blueprint.shares.each_value do |share|
-        next unless share.fetch("cleanup", true)
-
-        share_name = share.fetch("name")
-        database_name = share.fetch("database")
-        unless share_name.include?(branch_slug)
-          raise ValidationError, "Refusing to drop preview share without branch slug: #{share_name}"
-        end
-        share_url = sql(%(SELECT url FROM MD_LIST_DATABASE_SHARES() WHERE name = #{Util.sql_string(share_name)})).strip
-        if share_url.empty?
-          puts "No preview share found for '#{share_name}'"
-        else
-          puts "Dropping preview share #{share_name}"
-          sql(%(FROM MD_DROP_DATABASE_SHARE(#{Util.sql_string(share_name)});))
-        end
-
-        next unless share.fetch("dropDatabase", false)
-
-        unless database_name.include?(branch_slug)
-          raise ValidationError, "Refusing to drop preview database without branch slug: #{database_name}"
-        end
-        puts "Dropping preview database #{database_name}"
-        sql(%(DROP DATABASE IF EXISTS #{Util.quote_ident(database_name)};))
       end
     end
 
+    def list_flight_ids(name)
+      sql(%(SELECT flight_id FROM MD_LIST_FLIGHTS("offset" => 0::UINTEGER, "limit" => 1000::UINTEGER) WHERE flight_name = #{Util.sql_string(name)})).lines.map(&:strip).reject(&:empty?)
+    end
+
+    def list_dive_ids(title)
+      sql(%(SELECT id FROM MD_LIST_DIVES() WHERE title = #{Util.sql_string(title)})).lines.map(&:strip).reject(&:empty?)
+    end
+
+    def find_share_url(name)
+      sql(%(SELECT url FROM MD_LIST_DATABASE_SHARES() WHERE name = #{Util.sql_string(name)})).lines.first.to_s.strip
+    end
+
     def sql(statement)
-      Util.run_command("duckdb", "md:", "-csv", "-noheader", "-c", statement).strip
+      raise ValidationError, "MotherDuck token was not prepared for live command" unless @sql_env
+
+      Util.run_command("duckdb", "md:", "-csv", "-noheader", "-c", statement, env: @sql_env).strip
     end
   end
 
@@ -752,14 +1008,27 @@ module MDBlueprints
       when "changed"
         changed = project.changed_blueprints(base: options[:base], head: options[:head] || "HEAD")
         puts(options[:json] ? JSON.generate(changed) : changed.join("\n"))
+      when "plan"
+        target = options[:target] || "prod"
+        deployer = Deployer.new(project)
+        records = deployer.plan(target: target, branch: options[:branch], names: options[:blueprints])
+        puts(options[:json] ? JSON.pretty_generate(records.map(&:to_h)) : PlanFormatter.format(records, title: "Deployment Plan"))
+        deployer.ensure_plan_succeeds!(records)
       when "deploy"
         target = options[:target] || "prod"
         Deployer.new(project).deploy(target: target, branch: options[:branch], names: options[:blueprints])
       when "cleanup"
         target = options[:target] || "preview"
-        Deployer.new(project).cleanup(target: target, branch: options[:branch], names: options[:blueprints])
+        deployer = Deployer.new(project)
+        if options[:dry_run]
+          records = deployer.cleanup_plan(target: target, branch: options[:branch], names: options[:blueprints])
+          puts(options[:json] ? JSON.pretty_generate(records.map(&:to_h)) : PlanFormatter.format(records, title: "Cleanup Plan"))
+          deployer.ensure_plan_succeeds!(records)
+        else
+          deployer.cleanup(target: target, branch: options[:branch], names: options[:blueprints])
+        end
       else
-        warn "Usage: tools/md_blueprints <validate|render|changed|deploy|cleanup> [options]"
+        warn "Usage: tools/md_blueprints <validate|render|changed|plan|deploy|cleanup> [options]"
         exit 2
       end
     rescue ValidationError, CommandError, KeyError => e
@@ -777,6 +1046,7 @@ module MDBlueprints
         opts.on("--base REF") { |value| options[:base] = value }
         opts.on("--head REF") { |value| options[:head] = value }
         opts.on("--json") { options[:json] = true }
+        opts.on("--dry-run") { options[:dry_run] = true }
       end
       parser.parse!(argv)
       options


### PR DESCRIPTION
This PR adds a read-only deployment planning step so blueprint changes can inspect live MotherDuck state before creating, updating, or deleting resources. It also records target deployment identity metadata so preview and production can use different service account token env vars without changing blueprint package boundaries.

### Codex description

- add `tools/md_blueprints plan` and `cleanup --dry-run` with stable human and JSON output
- refactor deploy and cleanup to use inspected plans and fail before mutation on duplicate or unsafe resources
- wire CI to plan before preview and production deploys, and document the new lifecycle and target metadata
