### PR TITLE
docs: refresh repository guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,5 +14,6 @@
 - [ ] Preview shares/databases that can be cleaned up include `${target.branch_slug}`.
 - [ ] Blueprints validate with `make validate`.
 - [ ] Dives build with `make preview-smoke <blueprint-name>` when changed.
+- [ ] Docs are updated when layout, commands, target behavior, or resource semantics changed.
 - [ ] `CHANGELOG.md` is updated.
 - [ ] Production deploy has an owner/reviewer.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Guide
 
-This repository contains versioned MotherDuck Blueprints for Dives, Flights, shares, and future context-layer assets.
+This repository contains MotherDuck Blueprints for Dives, Flights, shares, and future context-layer assets.
 
 ## Token Handling
 
@@ -23,6 +23,8 @@ Do not add deployable resources under top-level `dives/`, `flights/`, or `bundle
 Treat a blueprint package as one logical project or data product. Do not split or group packages by MotherDuck organization, service account, user, or database ownership. Databases are resources inside a project package; service accounts are target or resource identity choices.
 
 Use `make new-blueprint <blueprint-name>` as the starting example for new projects. The generated package should stay deployable: its Flight creates starter data and a share, and its Dive reads that share.
+
+When changing layout, commands, target behavior, or resource semantics, update the relevant public docs in the same PR. Check at least `README.md`, `docs/`, blueprint `README.md` files, `templates/blueprint/README.md`, `context/README.md`, `.github/pull_request_template.md`, and this guide for drift.
 
 ## Resources
 
@@ -70,4 +72,4 @@ CI calls `tools/md_blueprints` directly for change detection, validation, previe
 
 ## Changelog
 
-Update `CHANGELOG.md` in every pull request. Keep entries under `Unreleased` until the change is released or merged into a reusable template.
+Update `CHANGELOG.md` in every pull request, including docs-only changes. Keep entries under `Unreleased` until the change is released or merged into a reusable template.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Update this file in every pull request. Add entries under `Unreleased` until the
 
 ### Changed
 
+- Refreshed agent and repository docs so validation checklists, generated-template guidance, context notes, and PR reminders stay aligned.
 - Expanded the generated starter blueprint with daily metrics, a summary view, an underscore-safe Dive alias, and a richer dashboard.
 - Migrated the Wikipedia Pageviews example into `blueprints/wikipedia-pageviews/`.
 - Ran read-only deployment plans before preview and production deploys in CI.

--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ Use this repo when you want:
 ```bash
 make validate
 make mock-test
+make example-smoke
 ```
 
 5. Open a small pull request and confirm the preview deployment comment appears.
 
 Use a MotherDuck service account token so deployed resources are owned by automation rather than by one person's account.
+Pull requests still validate without `MOTHERDUCK_TOKEN`, but live preview deployment starts only after that secret is configured.
 
 See [Set Up Your Repository](docs/setup-your-repository.md) for the full setup flow and [GitHub Setup](docs/github-setup.md) for the short GitHub checklist.
 
@@ -68,6 +70,7 @@ When you have a MotherDuck token configured, inspect live create/update/delete a
 - Deploy from CI with a service account token.
 - Use target `deployment` metadata when preview and production use different service accounts or token env vars.
 - Store secrets in GitHub Actions, never in the repo.
+- Keep README, `docs/`, blueprint README files, and the generated template README aligned when commands or layout rules change.
 - Update [CHANGELOG.md](CHANGELOG.md) in every pull request.
 
 ## Examples

--- a/blueprints/wikipedia-pageviews/README.md
+++ b/blueprints/wikipedia-pageviews/README.md
@@ -28,5 +28,6 @@ make preview-smoke wikipedia-pageviews
 ```bash
 make validate
 make mock-test
+make example-smoke
 ./tools/md_blueprints render --target preview --branch feature/example --blueprints wikipedia-pageviews
 ```

--- a/context/README.md
+++ b/context/README.md
@@ -9,6 +9,7 @@ Until then, use it to review and version proposed context files, for example:
 - `README.md` files beside concrete assets explaining ownership and review expectations.
 
 Until deployment is supported, package-local `resources.context` entries must use `deploy: false`.
+Document ownership, review expectations, and intended consumers beside concrete context assets. Update `docs/blueprint-yml-reference.md` and `docs/repository-reference.md` if context resource behavior changes.
 
 When MotherDuck exposes the deploy/update SQL functions or API for the context layer, add:
 

--- a/docs/blueprint-yml-reference.md
+++ b/docs/blueprint-yml-reference.md
@@ -358,7 +358,8 @@ Run these checks before opening a pull request:
 ```bash
 make validate
 make mock-test
+make example-smoke
 make preview-smoke <blueprint-name>
 ```
 
-`make validate` checks schemas, renders preview and production targets, enforces uniqueness, verifies file paths, parses Flight Python sources, and checks rendered resource rules. `make mock-test` exercises scaffold creation, live-state planning, preview deploy, production deploy, cleanup dry-runs, cleanup, and failed Flight run handling without contacting MotherDuck. Run `make preview-smoke <blueprint-name>` for every blueprint that includes a Dive.
+`make validate` checks schemas, renders preview and production targets, enforces uniqueness, verifies file paths, parses Flight Python sources, and checks rendered resource rules. `make mock-test` exercises scaffold creation, live-state planning, preview deploy, production deploy, cleanup dry-runs, cleanup, and failed Flight run handling without contacting MotherDuck. `make example-smoke` proves the generated starter package can be created, validated, built, and removed. Run `make preview-smoke <blueprint-name>` for every blueprint that includes a Dive.

--- a/docs/examples/wikipedia-pageviews.md
+++ b/docs/examples/wikipedia-pageviews.md
@@ -62,6 +62,7 @@ make validate
 make render-preview wikipedia-pageviews
 make preview-smoke wikipedia-pageviews
 make mock-test
+make example-smoke
 ```
 
 `make preview-smoke` builds the Dive through the local Vite preview harness without starting a long-running development server.

--- a/docs/github-setup.md
+++ b/docs/github-setup.md
@@ -79,10 +79,12 @@ Before opening a PR, run:
 ```bash
 make validate
 make mock-test
+make example-smoke
 make preview-smoke <blueprint-name>
 ```
 
 Skip `make preview-smoke` only when the changed blueprint has no Dive.
+For docs-only changes, still update `CHANGELOG.md` and keep the relevant README or `docs/` page in sync with any behavior you describe.
 
 Live workflows run `tools/md_blueprints plan` before deploy. You can run the same check locally with a MotherDuck token:
 

--- a/docs/repository-reference.md
+++ b/docs/repository-reference.md
@@ -34,6 +34,8 @@ context/
 
 `CHANGELOG.md` records notable repository changes. Update it in every pull request.
 
+Keep the docs set aligned when repository behavior changes. Layout, command, target, or resource changes should be reflected in `README.md`, the relevant `docs/` page, any affected blueprint README, the generated blueprint template README, `AGENTS.md`, and the pull request checklist.
+
 ## Project Granularity
 
 A `blueprints/<name>/` package represents one logical project or data product that should be reviewed, previewed, deployed, rolled back, and understood as a unit.
@@ -131,6 +133,8 @@ make mock-test
 make example-smoke
 make preview-smoke <blueprint-name> # when the blueprint has a Dive
 ```
+
+For docs-only changes, run at least `git diff --check`. Run the full validation set when docs describe generated output, manifests, workflows, or command behavior.
 
 ## CI/CD Flow
 

--- a/docs/setup-your-repository.md
+++ b/docs/setup-your-repository.md
@@ -162,3 +162,5 @@ You can then:
 - Add target `deployment.tokenEnvVar` and `deployment.identity` metadata in `motherduck.yml` if preview and production use different service account secrets.
 - Version context-layer assets under `context/` or package-local `resources.context` entries with `deploy: false`.
 - Update `.github/CODEOWNERS`.
+
+When you change repository commands, resource behavior, target policies, or package layout, update the matching docs in the same pull request and add an entry to `CHANGELOG.md`.

--- a/templates/blueprint/README.md
+++ b/templates/blueprint/README.md
@@ -20,6 +20,8 @@ The production target writes to the stable `__DATABASE_NAME__` database and shar
 
 ```bash
 make validate
+make mock-test
+make example-smoke
 make render-preview __BLUEPRINT_NAME__
 make preview-smoke __BLUEPRINT_NAME__
 ```


### PR DESCRIPTION
## Summary

Refresh the repository guidance so contributors and agents have one consistent view of the current blueprint layout, validation commands, and docs update expectations.

## What changed

- Remove stale versioned wording from `AGENTS.md`.
- Align setup, reference, example, and template docs around the full validation checklist, including `make example-smoke`.
- Clarify that PR validation can run without `MOTHERDUCK_TOKEN`, while live preview deploys wait for the secret.
- Add explicit reminders to keep README, `docs/`, blueprint README files, the generated template README, and the PR checklist in sync when behavior changes.
- Add the changelog entry for this docs refresh.

## Why

The repository behavior has moved toward a project-first blueprint package model with generated starter smoke coverage. These docs now describe that contract consistently across the surfaces contributors actually read.

## Verification

- `git diff --check`
- `make validate`
- `make mock-test`
- `make example-smoke`
- `make preview-smoke wikipedia-pageviews`