### PR TITLE
fix(cleanup): delete preview flights with named arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Update this file in every pull request. Add entries under `Unreleased` until the
 - Made preview Flight updates idempotent when schedules are already disabled, aligned Flight run SQL with live MotherDuck function signatures, and surfaced live SQL failures as CLI errors instead of tracebacks.
 - Added the MotherDuck runtime timezone dependency to generated starter Flight requirements.
 - Updated generated starter Flights to read share URLs through `MD_LIST_DATABASE_SHARES()`.
+- Updated preview cleanup to call Flight deletion with the live MotherDuck function signature.
 - Switched CI and deployment workflows to install and invoke the packaged `md-blueprints` command.
 - Kept `tools/md_blueprints` as a compatibility wrapper around the package command.
 - Documented that the template, CLI package, and action stay in one repository for this release, with modularization and repository split as follow-up criteria.

--- a/src/md_blueprints/deploy.py
+++ b/src/md_blueprints/deploy.py
@@ -569,7 +569,7 @@ class Deployer:
                 print(f"No preview Flight found for '{record.name}'")
             elif (record.type, record.action) == ("flight", "delete"):
                 print(f"Deleting preview Flight {record.id} ({record.name})")
-                self._sql(f"FROM MD_DELETE_FLIGHT('{record.id}'::UUID);")
+                self._sql(f"FROM MD_DELETE_FLIGHT(\"flight_id\" => '{record.id}'::UUID);")
             elif (record.type, record.action) == ("share", "missing"):
                 print(f"No preview share found for '{record.name}'")
             elif (record.type, record.action) == ("share", "drop_share"):

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -170,6 +170,28 @@ def test_flight_run_uses_named_motherduck_arguments(monkeypatch: pytest.MonkeyPa
     assert '"flight_id" => \'1a4ea2e6-0997-43ea-afe9-78c15c62220e\'::UUID' in run_call
 
 
+def test_cleanup_flight_delete_uses_named_motherduck_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
+    deployer = Deployer(Project(FIXTURES / "complex"))
+    calls: list[str] = []
+    monkeypatch.setattr(deployer, "_sql", lambda statement: calls.append(statement) or "")
+
+    deployer._apply_cleanup_plan(
+        [
+            PlanRecord(
+                blueprint="ops",
+                type="flight",
+                key="loader",
+                name="preview-loader",
+                action="delete",
+                exists=True,
+                id="1a4ea2e6-0997-43ea-afe9-78c15c62220e",
+            )
+        ]
+    )
+
+    assert calls == ['FROM MD_DELETE_FLIGHT("flight_id" => \'1a4ea2e6-0997-43ea-afe9-78c15c62220e\'::UUID);']
+
+
 def test_sql_identifier_quoting_rejects_unsafe_database_names() -> None:
     assert quote_ident("preview_database_1") == '"preview_database_1"'
 


### PR DESCRIPTION
Fix preview cleanup after branch deletion by matching the live MotherDuck `MD_DELETE_FLIGHT` function signature.

### Codex description

- call `MD_DELETE_FLIGHT` with the named `flight_id` argument
- add regression coverage for preview Flight cleanup SQL
- document the cleanup signature fix in the changelog