### PR TITLE
Allow pending PyPI trusted publisher in release preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Update this file in every pull request. Add entries under `Unreleased` until the
 - Documented and implemented escaped literal template placeholders with `\${...}`.
 - Updated docs and local setup guidance for PyPI installs, action `@v0`, the Python DuckDB runtime, and the schema compatibility matrix.
 - Updated customer docs and template docs to use generated repository setup instead of cloning the tooling repository.
+- Allowed the release external-setup preflight to accept a PyPI pending trusted publisher before the first package publish.
 - Made preview Flight updates idempotent when schedules are already disabled, aligned Flight run SQL with live MotherDuck function signatures, and surfaced live SQL failures as CLI errors instead of tracebacks.
 - Added the MotherDuck runtime timezone dependency to generated starter Flight requirements.
 - Updated generated starter Flights to read share URLs through `MD_LIST_DATABASE_SHARES()`.

--- a/scripts/check-release-external-setup.sh
+++ b/scripts/check-release-external-setup.sh
@@ -6,6 +6,9 @@ set -euo pipefail
 
 TEMPLATE_REPOSITORY="${TEMPLATE_REPOSITORY:-motherduckdb/blueprints-template}"
 PYPI_PROJECT="${PYPI_PROJECT:-md-blueprints}"
+PYPI_JSON_BASE_URL="${PYPI_JSON_BASE_URL:-https://pypi.org/pypi}"
+ALLOW_PYPI_PENDING_PUBLISHER="${ALLOW_PYPI_PENDING_PUBLISHER:-1}"
+export PYPI_JSON_BASE_URL ALLOW_PYPI_PENDING_PUBLISHER
 
 if [ -z "${TEMPLATE_PUSH_TOKEN:-}" ]; then
   echo "BLUEPRINTS_TEMPLATE_PUSH_TOKEN is not configured." >&2
@@ -41,19 +44,28 @@ python3 - "$PYPI_PROJECT" <<'PY'
 from __future__ import annotations
 
 import json
+import os
 import sys
 import urllib.error
 import urllib.request
 
 project = sys.argv[1]
-url = f"https://pypi.org/pypi/{project}/json"
+base_url = os.environ["PYPI_JSON_BASE_URL"].rstrip("/")
+allow_pending = os.environ["ALLOW_PYPI_PENDING_PUBLISHER"] == "1"
+url = f"{base_url}/{project}/json"
 try:
     with urllib.request.urlopen(url, timeout=10) as response:
         payload = json.loads(response.read().decode("utf-8"))
 except urllib.error.HTTPError as exc:
     if exc.code == 404:
+        if allow_pending:
+            print(
+                f"PyPI project {project!r} is not registered yet; assuming a pending trusted publisher "
+                "is configured to create it on first publish."
+            )
+            raise SystemExit(0) from exc
         raise SystemExit(
-            f"PyPI project {project!r} is not registered. Register it and configure trusted publishing "
+            f"PyPI project {project!r} is not registered. Register a pending trusted publisher "
             "for this repository, release.yaml, and the pypi environment before tagging a release."
         ) from exc
     raise

--- a/tests/test_release_external_setup.py
+++ b/tests/test_release_external_setup.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Iterator
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_release_external_check_accepts_existing_pypi_project(tmp_path: Path) -> None:
+    result = run_release_external_check(tmp_path, pypi_status=200)
+
+    assert result.returncode == 0
+    assert "Template repository OK: motherduckdb/blueprints-template" in result.stdout
+    assert "PyPI project OK: md-blueprints" in result.stdout
+
+
+def test_release_external_check_accepts_pending_pypi_publisher(tmp_path: Path) -> None:
+    result = run_release_external_check(tmp_path, pypi_status=404)
+
+    assert result.returncode == 0
+    assert "PyPI project 'md-blueprints' is not registered yet" in result.stdout
+    assert "pending trusted publisher" in result.stdout
+
+
+def test_release_external_check_can_require_registered_pypi_project(tmp_path: Path) -> None:
+    result = run_release_external_check(
+        tmp_path,
+        pypi_status=404,
+        extra_env={"ALLOW_PYPI_PENDING_PUBLISHER": "0"},
+    )
+
+    assert result.returncode == 1
+    assert "Register a pending trusted publisher" in result.stderr
+
+
+def run_release_external_check(
+    tmp_path: Path,
+    *,
+    pypi_status: int,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    gh = bin_dir / "gh"
+    gh.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+if [ "${GH_TOKEN:-}" != "template-token" ]; then
+  echo "missing GH_TOKEN" >&2
+  exit 2
+fi
+if [ "$1" != "api" ] || [ "$2" != "repos/motherduckdb/blueprints-template" ]; then
+  echo "unexpected gh invocation: $*" >&2
+  exit 2
+fi
+printf '{"is_template":true}'
+""",
+        encoding="utf-8",
+    )
+    gh.chmod(0o755)
+
+    with pypi_server(pypi_status) as base_url:
+        env = {
+            **os.environ,
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            "TEMPLATE_PUSH_TOKEN": "template-token",
+            "PYPI_JSON_BASE_URL": base_url,
+        }
+        if extra_env is not None:
+            env.update(extra_env)
+        return subprocess.run(
+            [str(REPO_ROOT / "scripts/check-release-external-setup.sh")],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+
+@contextlib.contextmanager
+def pypi_server(status: int) -> Iterator[str]:
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            if self.path != "/md-blueprints/json":
+                self.send_error(404)
+                return
+            self.send_response(status)
+            self.end_headers()
+            if status == 200:
+                self.wfile.write(json.dumps({"info": {"name": "md-blueprints"}}).encode("utf-8"))
+
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        thread.join()


### PR DESCRIPTION
## Summary

This follow-up fixes the release preflight for the first `md-blueprints` publish. PyPI pending trusted publishers intentionally leave the project JSON endpoint at 404 until the first OIDC-backed upload creates the project, so treating that 404 as a hard setup failure blocks the release path we just configured.

## What changed

- Allow `scripts/check-release-external-setup.sh` to accept a missing PyPI JSON project when using the default pending-publisher first-release mode.
- Keep a strict mode via `ALLOW_PYPI_PENDING_PUBLISHER=0` for cases where a pre-existing PyPI project must be required.
- Add pytest coverage with a stubbed `gh` binary and local PyPI JSON server for existing-project, pending-publisher, and strict-failure paths.
- Update the changelog.

## Verification

- `.venv/bin/python -m pytest`
- `.venv/bin/python -m mypy --strict src/md_blueprints`
- `make release-check TAG=v0.3.0`
- `make mock-test`
- `make validate`
- `make package-smoke`
