### PR TITLE
Require template token push permission in release preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Update this file in every pull request. Add entries under `Unreleased` until the
 - Updated docs and local setup guidance for PyPI installs, action `@v0`, the Python DuckDB runtime, and the schema compatibility matrix.
 - Updated customer docs and template docs to use generated repository setup instead of cloning the tooling repository.
 - Allowed the release external-setup preflight to accept a PyPI pending trusted publisher before the first package publish.
+- Required the generated-template token preflight to prove push permission, catching unapproved fine-grained token requests before release.
 - Made preview Flight updates idempotent when schedules are already disabled, aligned Flight run SQL with live MotherDuck function signatures, and surfaced live SQL failures as CLI errors instead of tracebacks.
 - Added the MotherDuck runtime timezone dependency to generated starter Flight requirements.
 - Updated generated starter Flights to read share URLs through `MD_LIST_DATABASE_SHARES()`.

--- a/scripts/check-release-external-setup.sh
+++ b/scripts/check-release-external-setup.sh
@@ -37,6 +37,11 @@ repository = sys.argv[1]
 payload = json.loads(sys.argv[2])
 if payload.get("is_template") is not True:
     raise SystemExit(f"{repository} exists but is not marked as a GitHub template repository")
+if payload.get("permissions", {}).get("push") is not True:
+    raise SystemExit(
+        f"BLUEPRINTS_TEMPLATE_PUSH_TOKEN can read {repository}, but cannot push to it. "
+        "Grant Contents: Read and write access to the template repository and approve any pending org request."
+    )
 print(f"Template repository OK: {repository}")
 PY
 

--- a/tests/test_release_external_setup.py
+++ b/tests/test_release_external_setup.py
@@ -28,6 +28,14 @@ def test_release_external_check_accepts_pending_pypi_publisher(tmp_path: Path) -
     assert "pending trusted publisher" in result.stdout
 
 
+def test_release_external_check_requires_template_push_permission(tmp_path: Path) -> None:
+    result = run_release_external_check(tmp_path, pypi_status=200, template_push=False)
+
+    assert result.returncode == 1
+    assert "cannot push" in result.stderr
+    assert "approve any pending org request" in result.stderr
+
+
 def test_release_external_check_can_require_registered_pypi_project(tmp_path: Path) -> None:
     result = run_release_external_check(
         tmp_path,
@@ -43,6 +51,7 @@ def run_release_external_check(
     tmp_path: Path,
     *,
     pypi_status: int,
+    template_push: bool = True,
     extra_env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     bin_dir = tmp_path / "bin"
@@ -59,7 +68,7 @@ if [ "$1" != "api" ] || [ "$2" != "repos/motherduckdb/blueprints-template" ]; th
   echo "unexpected gh invocation: $*" >&2
   exit 2
 fi
-printf '{"is_template":true}'
+printf '{"is_template":true,"permissions":{"push":%s}}' "${GH_TEMPLATE_PUSH}"
 """,
         encoding="utf-8",
     )
@@ -70,6 +79,7 @@ printf '{"is_template":true}'
             **os.environ,
             "PATH": f"{bin_dir}:{os.environ['PATH']}",
             "TEMPLATE_PUSH_TOKEN": "template-token",
+            "GH_TEMPLATE_PUSH": "true" if template_push else "false",
             "PYPI_JSON_BASE_URL": base_url,
         }
         if extra_env is not None:


### PR DESCRIPTION
## Summary

This tightens the release external-setup preflight so it proves the generated-template token can actually push to `motherduckdb/blueprints-template`. A public repository read is not enough: an unapproved fine-grained PAT can still read the repo while failing later when `publish-template` force-pushes.

## What changed

- Require `permissions.push == true` in the repository API payload returned while authenticated with `BLUEPRINTS_TEMPLATE_PUSH_TOKEN`.
- Emit an actionable error that points at `Contents: Read and write` and pending org approval.
- Add regression coverage for the no-push-permission failure path.
- Update the changelog.

## Verification

- `.venv/bin/python -m pytest tests/test_release_external_setup.py`
- `.venv/bin/python -m pytest`
- `.venv/bin/python -m mypy --strict src/md_blueprints`
- `make validate`
- `make release-check TAG=v0.3.0`
- `make mock-test`
