### PR TITLE
Rewrite README for customer-facing audience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Update this file in every pull request. Add entries under `Unreleased` until the
 
 ### Changed
 
+- Rewrote the repository `README.md` for a customer-facing audience: clarified what Blueprints is, documented the relationship between this repository, the `md-blueprints` package/action, and the generated `blueprints-template` repository, added the template-based quickstart, and removed hardcoded version pins. Added the missing Node.js prerequisite to the repository and template READMEs.
 - Converted customer-facing deploy and cleanup workflows to run the pinned `motherduckdb/motherduck-blueprints` action instead of installing the local checkout.
 - Kept tooling-repository deploy and doctor workflows on the local action checkout while generated customer workflows use the stamped public action tag.
 - Updated the action to expose raw CLI stdout and install the deploy extra only for live commands.

--- a/README.md
+++ b/README.md
@@ -1,47 +1,52 @@
 # MotherDuck Blueprints
 
-MotherDuck Blueprints gives you a repository pattern for shipping MotherDuck Flights, Dives, shares, and future context assets. Pull requests validate blueprints, deploy branch-scoped previews, and leave a PR comment with the deployment plan and preview links; merges to `main` deploy stable production resources through a protected GitHub Environment.
+MotherDuck Blueprints lets you manage MotherDuck resources the same way you manage application code: in a Git repository, reviewed through pull requests, and deployed by CI.
 
-Preview comments look like this:
+A blueprint is a small package that declares one data project — its Flights (scheduled Python jobs), Dives (interactive data apps), and shares — in a `blueprint.yml` manifest next to its source code. From there:
 
-```md
-### Preview Blueprints
+- **Pull requests** validate every blueprint, deploy branch-scoped previews, and leave a comment on the PR with the deployment plan and preview links.
+- **Merges to `main`** deploy stable production resources through a protected GitHub Environment.
+- **Branch cleanup** removes preview resources when the branch is deleted.
 
-#### Deployment Plan
+## What's in this repository
 
-| Blueprint | Type | Key | Name | Action | Exists | ID | Notes |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| wikipedia-pageviews | flight | loader | wikipedia-pageviews:feature/example (Preview) | create | no |  |  |
+This repository is the source for the Blueprints tooling. As a user, you interact with three artifacts built from it:
 
-#### Wikipedia Pageviews
-
-##### Shares
-
-| Share | Link |
-|-------|------|
-| wikipedia_pageviews_preview_feature_example | Open Share |
-```
+| Artifact | What it is |
+| --- | --- |
+| [`motherduckdb/blueprints-template`](https://github.com/motherduckdb/blueprints-template) | A GitHub template repository — the fastest way to start. It is generated from this repository on each release, so don't open pull requests there. |
+| [`md-blueprints` on PyPI](https://pypi.org/project/md-blueprints/) | The CLI for validating, planning, deploying, and migrating blueprints, locally or in CI. |
+| `motherduckdb/motherduck-blueprints@v0` | The GitHub Action that the generated workflows use to run the CLI in CI. |
 
 ## Prerequisites
 
 - Python 3.10 or newer.
-- GitHub Actions secrets and a protected `motherduck-production` environment.
-- A MotherDuck service account token for CI deployments.
-
-Use a service account token so deployed resources are owned by automation rather than by one person's account.
+- Node.js 20 or newer (only needed to preview Dives locally).
+- A GitHub repository with Actions enabled.
+- A MotherDuck service account token for CI deployments, so deployed resources are owned by automation rather than by one person's account.
 
 ## Quickstart
 
-Generate a customer repository from the released CLI:
+### 1. Create your repository
+
+Use the template repository (recommended):
+
+```bash
+gh repo create <your-org>/motherduck-blueprints \
+  --template motherduckdb/blueprints-template --private --clone
+cd motherduck-blueprints
+```
+
+Or generate the same file set with the CLI:
 
 ```bash
 python3 -m venv .venv
-.venv/bin/python -m pip install "md-blueprints==0.3.0"
+.venv/bin/python -m pip install md-blueprints
 .venv/bin/md-blueprints init motherduck-blueprints
 cd motherduck-blueprints
 ```
 
-Start without touching MotherDuck:
+### 2. Try it locally, without a MotherDuck token
 
 ```bash
 make setup
@@ -49,16 +54,18 @@ make validate
 make preview-smoke wikipedia-pageviews
 ```
 
-Then connect MotherDuck:
+The repository ships with a working example, [wikipedia-pageviews](docs/examples/wikipedia-pageviews.md): a Flight that loads public data and publishes a share, plus a Dive that reads that share.
 
-1. Add a GitHub Actions secret named `MOTHERDUCK_TOKEN`.
-2. Create a GitHub Environment named `motherduck-production`.
+### 3. Connect MotherDuck
+
+1. Add a GitHub Actions secret named `MOTHERDUCK_TOKEN` containing your service account token.
+2. Create a GitHub Environment named `motherduck-production` with required reviewers.
 3. Open a small pull request and confirm the preview deployment comment appears.
 4. Merge after review to deploy production through the protected environment.
 
 See [Set Up Your Repository](docs/setup-your-repository.md) for the full setup flow and [GitHub Setup](docs/github-setup.md) for the GitHub checklist.
 
-## Add a Blueprint
+## Add a blueprint
 
 A blueprint is one logical project or data product. Keep its manifest, Flight, Dive, and README together:
 
@@ -72,7 +79,7 @@ blueprints/<blueprint-name>/
     dive.tsx
 ```
 
-Start with the scaffold:
+Start from the scaffold, then replace the starter Flight and Dive with your real project logic:
 
 ```bash
 make new-blueprint revenue-overview
@@ -80,20 +87,31 @@ make validate
 make preview-smoke revenue-overview
 ```
 
-Then replace the starter Flight and Dive with your real project logic.
-
-When you have a MotherDuck token configured, inspect live create/update/delete actions before applying them:
+Once a MotherDuck token is configured, you can inspect live create/update/delete actions before applying them:
 
 ```bash
 .venv/bin/md-blueprints plan --target preview --branch feature/example --blueprints revenue-overview
 .venv/bin/md-blueprints cleanup --dry-run --target preview --branch feature/example --blueprints revenue-overview
 ```
 
-## Versioning
+## How deployments work
 
-Customer repositories upgrade by bumping the pinned action or package version. The template is the starting point; the `md-blueprints` package and action are the long-term tooling contract.
+Every pull request gets a comment with the deployment plan and preview links:
 
-Use the current major action tag in workflows:
+```md
+### Preview Blueprints
+
+| Blueprint | Type | Key | Name | Action |
+| --- | --- | --- | --- | --- |
+| wikipedia-pageviews | flight | loader | wikipedia-pageviews:feature/example (Preview) | create |
+```
+
+- **Preview** deployments are branch-scoped: preview share and database names include the branch slug, Flight schedules are disabled, and resources are cleaned up when the branch goes away.
+- **Production** deployments run only from `main`, through the `motherduck-production` GitHub Environment, so you can require manual approval before anything changes.
+
+## Versioning and upgrades
+
+Your repository pins the tooling in two places: the action tag in `.github/workflows/` and the CLI version installed locally. Upgrade by bumping those pins.
 
 ```yaml
 - uses: motherduckdb/motherduck-blueprints@v0
@@ -101,40 +119,25 @@ Use the current major action tag in workflows:
     command: validate
 ```
 
-Install the CLI locally from PyPI:
+Minor releases are additive and safe to accept through Dependabot after preview validation. Major releases can introduce a new manifest `schemaVersion`; run `md-blueprints doctor` and `md-blueprints migrate --to latest` first. See [Tooling and Schema Versioning](docs/tooling-and-schema-versioning.md) for the compatibility policy.
+
+Live `plan`, `deploy`, and `cleanup` commands need the deploy extra, which includes the DuckDB runtime dependencies:
 
 ```bash
-python3 -m venv .venv
-.venv/bin/python -m pip install "md-blueprints==0.3.0"
-.venv/bin/md-blueprints validate
+.venv/bin/python -m pip install "md-blueprints[deploy]"
 ```
 
-Live `plan`, `deploy`, and `cleanup` commands need the deploy extra, which includes the DuckDB Python runtime dependencies for MotherDuck:
-
-```bash
-.venv/bin/python -m pip install "md-blueprints[deploy]==0.3.0"
-```
-
-| action / CLI | schemaVersions supported | upgrade path |
-| --- | --- | --- |
-| v0.x | 1 | Current pre-1.0 contract |
-| v1.x | 1 | First stable customer contract |
-| v2.x | 1 deprecated, removed in v3; 2 current | Run `md-blueprints doctor` and `md-blueprints migrate --to latest` before bumping |
-
-Minor releases are additive and should be safe to accept through Dependabot after preview validation. Major releases can introduce a new `schemaVersion`; run `doctor` and `migrate` first.
-
-## Best Practices
+## Best practices
 
 - Keep one project or data product per `blueprints/<name>/` package.
 - Use lowercase slug names such as `account-360` or `revenue-ops`.
-- Keep preview resources branch-scoped and production resources stable.
 - Run a deployment plan before live deploys and use cleanup dry-runs before deleting previews.
-- Deploy from CI with a service account token.
-- Store secrets in GitHub Actions, never in the repo.
+- Deploy from CI with a service account token; store secrets in GitHub Actions, never in the repo.
 
-## More Detail
+## Learn more
 
 - [Repository Reference](docs/repository-reference.md): layout, targets, local commands, CI/CD, and context-layer notes.
 - [blueprint.yml Reference](docs/blueprint-yml-reference.md): complete field reference for blueprint manifests.
-- [Tooling and Schema Versioning](docs/tooling-and-schema-versioning.md): package/action pinning, schema compatibility, migrations, release engineering, and future repo-split guidance.
-- [Wikipedia Pageviews example](docs/examples/wikipedia-pageviews.md): a Flight that loads public data, publishes a share, and deploys a Dive that reads that share.
+- [Tooling and Schema Versioning](docs/tooling-and-schema-versioning.md): package/action pinning, schema compatibility, and migrations.
+- [Wikipedia Pageviews example](docs/examples/wikipedia-pageviews.md): the end-to-end example blueprint.
+- [MotherDuck documentation](https://motherduck.com/docs/getting-started) and the [MotherDuck Community Slack](https://slack.motherduck.com/) for product questions and support.

--- a/src/md_blueprints/template_repo/README.md
+++ b/src/md_blueprints/template_repo/README.md
@@ -7,6 +7,7 @@ If you are reading this in `motherduckdb/blueprints-template`, do not open pull 
 ## Prerequisites
 
 - Python 3.10 or newer.
+- Node.js 20 or newer (only needed to preview Dives locally).
 - GitHub Actions secrets and a protected `motherduck-production` environment.
 - A MotherDuck service account token for CI deployments.
 


### PR DESCRIPTION
## What changed

- Rewrote `README.md` for customers:
  - Opens with what Blueprints is and what the PR/merge/cleanup lifecycle does, instead of leading with a preview-comment dump.
  - New "What's in this repository" section explaining the three artifacts customers actually consume: the `blueprints-template` GitHub template repo, the `md-blueprints` PyPI package, and the `@v0` GitHub Action.
  - Quickstart now leads with the template repository (`gh repo create --template`), with `md-blueprints init` as the alternative.
  - Removed hardcoded `==0.3.0` pins and the speculative v1/v2/v3 schema table; links to the versioning doc instead.
  - Added Node.js prerequisite (required by `make setup` / local Dive preview) and links to MotherDuck docs and Community Slack.
- Added the Node.js prerequisite to the generated template README as well.
- Updated `CHANGELOG.md`.

## Checks

- `make validate` passes
- `pytest tests` passes (32/32)