### PR TITLE
fix: harden blueprint deployment safety

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,7 @@ jobs:
         run: python -m pytest
 
       - name: Type-check package
-        run: python -m mypy --strict src/md_blueprints
+        run: python -m mypy --strict src/md_blueprints tests
 
       - name: Run mock deployment tests
         run: make mock-test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: Release Package Artifacts
 
 permissions:
-  contents: write
+  contents: read
 
 on:
   workflow_dispatch:
@@ -45,32 +45,6 @@ jobs:
         with:
           name: md-blueprints-dist
           path: dist/*
-
-      - name: Publish GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v')
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          tag="${GITHUB_REF_NAME}"
-          if gh release view "$tag" >/dev/null 2>&1; then
-            gh release upload "$tag" dist/* --clobber
-          else
-            gh release create "$tag" dist/* \
-              --verify-tag \
-              --title "$tag" \
-              --notes "md-blueprints package artifacts for ${tag}."
-          fi
-
-      - name: Update floating major tag
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          set -euo pipefail
-          major="v$(echo "${GITHUB_REF_NAME#v}" | cut -d. -f1)"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -f "$major" "$GITHUB_SHA"
-          git push -f origin "$major"
 
   release-preflight:
     name: Verify External Release Setup
@@ -177,3 +151,46 @@ jobs:
           elif ! gh release create "$tag" -R "$TEMPLATE_REPOSITORY" --verify-tag --title "$tag" --notes "$notes"; then
             echo "::warning::Could not create a release on ${TEMPLATE_REPOSITORY}; the tag ${tag} was still pushed."
           fi
+
+  finalize-release:
+    name: Publish GitHub Release
+    needs:
+      - publish-pypi
+      - publish-template
+    if: github.repository == 'motherduckdb/motherduck-blueprints' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: md-blueprints-dist
+          path: dist
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release upload "$tag" dist/* --clobber
+          else
+            gh release create "$tag" dist/* \
+              --verify-tag \
+              --title "$tag" \
+              --notes "md-blueprints package artifacts for ${tag}."
+          fi
+
+      - name: Update floating major tag
+        run: |
+          set -euo pipefail
+          major="v$(echo "${GITHUB_REF_NAME#v}" | cut -d. -f1)"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -f "$major" "$GITHUB_SHA"
+          git push -f origin "$major"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this repository are documented here.
 
 Update this file in every pull request. Add entries under `Unreleased` until the change is released or merged into a reusable template.
 
+## Unreleased
+
+### Changed
+
+- Hardened preview cleanup so Flights, Dives, shares, and databases must be branch-scoped, cannot reuse their production identifiers, and require an explicit target-policy opt-in.
+- Validated live preview operations with the requested branch instead of the validator's mock branch.
+- Restricted included manifests and resource source files to their repository and blueprint package boundaries, including after symlink resolution.
+- Made `md-blueprints init --force` refuse template destinations that resolve outside the target directory through symlinks.
+- Delayed GitHub Release publication and floating-tag updates until release preflight, PyPI publishing, and generated-template publishing succeed, and narrowed the default release workflow permission to read-only.
+
+### Fixed
+
+- Fixed the full test-suite mypy failure in the cleanup SQL regression test and added tests to the strict CI type-check.
+
 ## v0.3.0 - 2026-07-02
 
 ### Added

--- a/docs/blueprint-yml-reference.md
+++ b/docs/blueprint-yml-reference.md
@@ -33,6 +33,8 @@ resources:
 
 The `resources` object is required. Each resource group inside it is optional, so a blueprint can contain any combination of shares, Flights, Dives, and context resources.
 
+All resource `source` and `requirements` paths must resolve inside the blueprint package directory. Absolute paths, `..` traversal, and symlinks that escape the package are rejected so validation and deployment cannot read files from elsewhere on the runner.
+
 ## Rendering Model
 
 `blueprint.yml` is first validated as YAML and then rendered for a target such as `preview` or `prod`.
@@ -205,6 +207,7 @@ Rendered Flight validation:
 
 - `name`, `source`, and `requirements` must be non-empty after rendering.
 - `source` and `requirements` files must exist.
+- `source` and `requirements` must stay inside the blueprint package, including after resolving symlinks.
 - `source` must parse as valid Python.
 - Non-empty `scheduleCron` values must contain exactly 5 fields.
 - In the default preview target, schedules are disabled by policy and render as `""` even if the base Flight sets `scheduleCron`.

--- a/docs/repository-reference.md
+++ b/docs/repository-reference.md
@@ -30,6 +30,8 @@ context/
 
 `motherduck.yml` is the canonical repository manifest. It declares included blueprint manifests, shared variables, and the `preview` and `prod` targets. GitHub Actions discover changed blueprints from this manifest instead of requiring manual path-filter registration.
 
+`include` entries must be relative glob patterns that stay inside the repository root. Overlapping globs are deduplicated, and blueprint names must be unique across all matched manifests.
+
 The root manifest may also set `requiredCliVersion`, for example `requiredCliVersion: ">=1.3"`, when a repository depends on CLI behavior that cannot be expressed through schema shape alone.
 
 `md-blueprints` is the versioned CLI package that validates schemas, renders targets, plans deployments, deploys resources, cleans previews, and hosts migration commands.
@@ -99,6 +101,10 @@ The repo defines two targets:
 - `prod`: stable production names, protected by the `motherduck-production` GitHub Environment.
 
 Preview resources must include `${target.branch_slug}` in cleanup-sensitive share/database names. This prevents cleanup from dropping stable production resources.
+
+Preview Flight names and Dive titles must also contain either `${target.branch}` or `${target.branch_slug}`. Cleanup refuses any Flight, Dive, share, or database whose preview identifier is not branch-scoped or exactly matches its production identifier.
+
+The cleanup command also requires `targets.preview.policies.cleanup: true`; without that explicit opt-in it exits before querying or deleting resources.
 
 ## Local Commands
 

--- a/docs/tooling-and-schema-versioning.md
+++ b/docs/tooling-and-schema-versioning.md
@@ -103,10 +103,10 @@ Tagged `v*` pushes run the release workflow:
 2. Build the wheel and source distribution.
 3. Smoke test the installed wheel.
 4. Smoke test the local action wrapper.
-5. Attach artifacts to the matching GitHub Release.
+5. Verify the external PyPI and template-repository setup before publishing anything.
 6. Publish to PyPI through trusted publishing.
-7. Force-update the floating major tag, for example `v0`.
-8. Generate the customer template with the built wheel and force-push it to `motherduckdb/blueprints-template` when `BLUEPRINTS_TEMPLATE_PUSH_TOKEN` is configured.
+7. Generate the customer template with the built wheel and push it to `motherduckdb/blueprints-template`.
+8. Attach artifacts to the matching GitHub Release and only then update the floating major tag, for example `v0`.
 
 One-time PyPI setup: register the `md-blueprints` project and add a trusted publisher for this repository, `release.yaml`, and the `pypi` environment. Tagged releases run `scripts/check-release-external-setup.sh` before publishing so a missing project or trusted-publishing setup fails with an actionable error.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,4 +46,5 @@ md_blueprints = [
 [tool.mypy]
 exclude = [
   "src/md_blueprints/template_repo/",
+  "tests/fixtures/",
 ]

--- a/src/md_blueprints/deploy.py
+++ b/src/md_blueprints/deploy.py
@@ -139,10 +139,22 @@ class Deployer:
     def cleanup_plan(self, *, target: str, branch: str | None, names: list[str] | None) -> list[PlanRecord]:
         if target != "preview":
             raise ValidationError("cleanup is only supported for preview target")
+        policies = self.project.target_config(target).get("policies", {})
+        if not isinstance(policies, dict) or policies.get("cleanup") is not True:
+            raise ValidationError("cleanup is disabled by the preview target policy")
 
         rendered = self._validate_and_render(target, branch, names)
         self._prepare_live_command(target, "cleanup")
-        return self._build_cleanup_plan(rendered, branch_slug(branch or ""))
+        production = {
+            blueprint.name: blueprint
+            for blueprint in self.project.render_all("prod", names=names)
+        }
+        return self._build_cleanup_plan(
+            rendered,
+            branch_slug(branch or ""),
+            branch=branch,
+            production=production,
+        )
 
     def cleanup(self, *, target: str, branch: str | None, names: list[str] | None) -> None:
         records = self.cleanup_plan(target=target, branch=branch, names=names)
@@ -162,7 +174,7 @@ class Deployer:
         branch: str | None,
         names: list[str] | None,
     ) -> list[RenderedBlueprint]:
-        self.project.validate(targets=[target])
+        self.project.validate(targets=[target], branch=branch)
         return self.project.render_all(target, branch=branch, names=names)
 
     def _prepare_live_command(self, target: str, operation: str) -> None:
@@ -232,11 +244,30 @@ class Deployer:
                 )
         return records
 
-    def _build_cleanup_plan(self, rendered: list[RenderedBlueprint], rendered_branch_slug: str) -> list[PlanRecord]:
+    def _build_cleanup_plan(
+        self,
+        rendered: list[RenderedBlueprint],
+        rendered_branch_slug: str,
+        *,
+        branch: str | None = None,
+        production: dict[str, RenderedBlueprint] | None = None,
+    ) -> list[PlanRecord]:
         records: list[PlanRecord] = []
         for blueprint in rendered:
+            production_blueprint = production.get(blueprint.name) if production else None
             for key, dive in blueprint.dives.items():
                 title = str(dive["title"])
+                production_title = None
+                if production_blueprint and key in production_blueprint.dives:
+                    production_title = str(production_blueprint.dives[key]["title"])
+                safety_error = self._preview_scope_error(
+                    "Dive", title, branch, rendered_branch_slug, production_title
+                )
+                if safety_error:
+                    records.append(
+                        self._cleanup_record(blueprint, "dive", key, title, "error", None, None, safety_error)
+                    )
+                    continue
                 ids = self._list_dive_ids(title)
                 if not ids:
                     records.append(self._cleanup_record(blueprint, "dive", key, title, "missing", False, None))
@@ -246,6 +277,17 @@ class Deployer:
 
             for key, flight in blueprint.flights.items():
                 name = str(flight["name"])
+                production_name = None
+                if production_blueprint and key in production_blueprint.flights:
+                    production_name = str(production_blueprint.flights[key]["name"])
+                safety_error = self._preview_scope_error(
+                    "Flight", name, branch, rendered_branch_slug, production_name
+                )
+                if safety_error:
+                    records.append(
+                        self._cleanup_record(blueprint, "flight", key, name, "error", None, None, safety_error)
+                    )
+                    continue
                 ids = self._list_flight_ids(name)
                 if not ids:
                     records.append(self._cleanup_record(blueprint, "flight", key, name, "missing", False, None))
@@ -259,7 +301,12 @@ class Deployer:
 
                 share_name = str(share["name"])
                 database_name = str(share["database"])
-                if rendered_branch_slug not in share_name:
+                production_share = production_blueprint.shares.get(key) if production_blueprint else None
+                production_share_name = str(production_share["name"]) if production_share else None
+                share_safety_error = self._preview_scope_error(
+                    "share", share_name, branch, rendered_branch_slug, production_share_name
+                )
+                if share_safety_error:
                     records.append(
                         self._cleanup_record(
                             blueprint,
@@ -269,7 +316,7 @@ class Deployer:
                             "error",
                             None,
                             None,
-                            f"refusing to drop preview share without branch slug {rendered_branch_slug}",
+                            share_safety_error,
                         )
                     )
                     continue
@@ -283,7 +330,11 @@ class Deployer:
                 if not share.get("dropDatabase", False):
                     continue
 
-                if rendered_branch_slug not in database_name:
+                production_database_name = str(production_share["database"]) if production_share else None
+                database_safety_error = self._preview_scope_error(
+                    "database", database_name, branch, rendered_branch_slug, production_database_name
+                )
+                if database_safety_error:
                     records.append(
                         self._cleanup_record(
                             blueprint,
@@ -293,7 +344,7 @@ class Deployer:
                             "error",
                             None,
                             None,
-                            f"refusing to drop preview database without branch slug {rendered_branch_slug}",
+                            database_safety_error,
                         )
                     )
                     continue
@@ -311,6 +362,24 @@ class Deployer:
                     )
                 )
         return records
+
+    @staticmethod
+    def _preview_scope_error(
+        resource_type: str,
+        name: str,
+        branch: str | None,
+        rendered_branch_slug: str,
+        production_name: str | None,
+    ) -> str | None:
+        if production_name is not None and name == production_name:
+            return f"refusing to delete preview {resource_type} because it matches production: {name}"
+        branch_markers = {rendered_branch_slug}
+        if branch:
+            branch_markers.add(branch)
+        if not any(marker and marker in name for marker in branch_markers):
+            action = "drop" if resource_type in {"share", "database"} else "delete"
+            return f"refusing to {action} preview {resource_type} without branch slug {rendered_branch_slug}"
+        return None
 
     def _existing_resource_record(
         self,

--- a/src/md_blueprints/init.py
+++ b/src/md_blueprints/init.py
@@ -44,7 +44,7 @@ def run_init(target: Path, *, force: bool = False) -> None:
     for resource, relative in iter_resources(template_root):
         if not relative or "/__pycache__/" in f"/{relative}/":
             continue
-        destination = target / relative
+        destination = safe_destination(target, relative)
         if resource.is_dir():
             destination.mkdir(parents=True, exist_ok=True)
             continue
@@ -59,3 +59,12 @@ def run_init(target: Path, *, force: bool = False) -> None:
     print(f"Initialized MotherDuck Blueprints template in {target} ({written} files).")
     print(f"CLI version pinned in Makefile: {__version__}")
     print(f"Action tag pinned in workflows: {action_major_tag()}")
+
+
+def safe_destination(target: Path, relative: str) -> Path:
+    destination = target / relative
+    try:
+        destination.resolve(strict=False).relative_to(target)
+    except ValueError as exc:
+        raise ValidationError(f"Refusing to write template path outside {target}: {relative}") from exc
+    return destination

--- a/src/md_blueprints/project.py
+++ b/src/md_blueprints/project.py
@@ -107,17 +107,19 @@ class Project:
         self.schema.validate(self.manifest, "motherduck-root.schema.json")
         self.blueprints = self._load_blueprints()
 
-    def validate(self, targets: list[str] | None = None) -> bool:
+    def validate(self, targets: list[str] | None = None, *, branch: str | None = None) -> bool:
         target_names = targets or ["preview", "prod"]
         if not self.blueprints:
             raise ValidationError("No blueprints found from include globs")
 
         for target in target_names:
-            branch = "feature/mock-test" if target == "preview" else None
-            rendered = self.render_all(target, branch=branch)
+            rendered_branch = (branch or "feature/mock-test") if target == "preview" else None
+            rendered = self.render_all(target, branch=rendered_branch)
             self._validate_uniqueness(target, rendered)
             for blueprint in rendered:
-                self._validate_rendered_blueprint(target, branch, blueprint)
+                self._validate_rendered_blueprint(target, rendered_branch, blueprint)
+            if target == "preview":
+                self._validate_preview_separation(rendered, self.render_all("prod"))
         return True
 
     def render_all(
@@ -184,19 +186,31 @@ class Project:
         if not isinstance(include, list):
             raise ValidationError("$.include must be array")
 
-        paths: list[Path] = []
+        paths: set[Path] = set()
         for pattern in include:
-            paths.extend(self.root.glob(str(pattern)))
+            rendered_pattern = str(pattern)
+            pattern_path = Path(rendered_pattern)
+            if pattern_path.is_absolute() or ".." in pattern_path.parts:
+                raise ValidationError(f"Include pattern must stay within the project root: {rendered_pattern}")
+            for path in self.root.glob(rendered_pattern):
+                paths.add(require_within(path, self.root, f"Included blueprint {path}"))
 
         blueprints: list[Blueprint] = []
+        blueprint_paths: dict[str, Path] = {}
         for path in sorted(paths):
             raw = load_yaml(path)
             if not isinstance(raw, dict):
                 raise ValidationError(f"{path} must be an object")
             self.schema.validate(raw, "blueprint.schema.json")
+            name = str(raw["name"])
+            if name in blueprint_paths:
+                raise ValidationError(
+                    f"Duplicate blueprint name {name!r}: {blueprint_paths[name]} and {path}"
+                )
+            blueprint_paths[name] = path
             blueprints.append(
                 Blueprint(
-                    name=str(raw["name"]),
+                    name=name,
                     title=str(raw["title"]),
                     path=path,
                     dir=path.parent,
@@ -260,8 +274,20 @@ class Project:
 
         flights = self._render_resources(resources_node.get("flights", {}), target, context)
         for flight in flights.values():
-            flight["sourcePath"] = str((blueprint.dir / str(flight["source"])).resolve())
-            flight["requirementsPath"] = str((blueprint.dir / str(flight["requirements"])).resolve())
+            flight["sourcePath"] = str(
+                require_within(
+                    blueprint.dir / str(flight["source"]),
+                    blueprint.dir,
+                    f"Flight source for {blueprint.name}",
+                )
+            )
+            flight["requirementsPath"] = str(
+                require_within(
+                    blueprint.dir / str(flight["requirements"]),
+                    blueprint.dir,
+                    f"Flight requirements for {blueprint.name}",
+                )
+            )
             policies = target_settings.get("policies", {})
             if target == "preview" and isinstance(policies, dict) and policies.get("disableSchedules") is True:
                 flight["scheduleCron"] = ""
@@ -275,12 +301,24 @@ class Project:
 
         dives = self._render_resources(resources_node.get("dives", {}), target, context)
         for dive in dives.values():
-            dive["sourcePath"] = str((blueprint.dir / str(dive["source"])).resolve())
+            dive["sourcePath"] = str(
+                require_within(
+                    blueprint.dir / str(dive["source"]),
+                    blueprint.dir,
+                    f"Dive source for {blueprint.name}",
+                )
+            )
             dive.setdefault("description", "")
 
         contexts = self._render_resources(resources_node.get("context", {}), target, context)
         for ctx in contexts.values():
-            ctx["sourcePath"] = str((blueprint.dir / str(ctx["source"])).resolve())
+            ctx["sourcePath"] = str(
+                require_within(
+                    blueprint.dir / str(ctx["source"]),
+                    blueprint.dir,
+                    f"Context source for {blueprint.name}",
+                )
+            )
             ctx["deploy"] = ctx.get("deploy", False)
 
         return RenderedBlueprint(
@@ -389,12 +427,26 @@ class Project:
                 and schedule
             ):
                 raise ValidationError(f"preview flight {blueprint.name}.{key} must render with schedule disabled")
+            if (
+                target == "preview"
+                and not includes_branch_scope(str(flight["name"]), branch)
+            ):
+                raise ValidationError(
+                    f"preview Flight {blueprint.name}.{key} must include branch name or slug {rendered_branch_slug}"
+                )
 
         for key, dive in blueprint.dives.items():
             for field in ["title", "sourcePath"]:
                 require_nonempty(dive.get(field), f"dives.{key}.{field}")
             require_file(Path(str(dive["sourcePath"])))
             required_resources = dive.get("requiredResources")
+            if (
+                target == "preview"
+                and not includes_branch_scope(str(dive["title"]), branch)
+            ):
+                raise ValidationError(
+                    f"preview Dive {blueprint.name}.{key} must include branch name or slug {rendered_branch_slug}"
+                )
             if not isinstance(required_resources, list) or not required_resources:
                 raise ValidationError(f"dives.{key}.requiredResources must not be empty")
 
@@ -417,6 +469,33 @@ class Project:
                     f"context resource {blueprint.name}.{key} cannot deploy until MotherDuck exposes the context API"
                 )
 
+    def _validate_preview_separation(
+        self,
+        preview_blueprints: list[RenderedBlueprint],
+        production_blueprints: list[RenderedBlueprint],
+    ) -> None:
+        production = {blueprint.name: blueprint for blueprint in production_blueprints}
+        resource_fields = [
+            ("Flight", "flights", "name"),
+            ("Dive", "dives", "title"),
+            ("share", "shares", "name"),
+            ("database", "shares", "database"),
+        ]
+        for preview in preview_blueprints:
+            prod = production.get(preview.name)
+            if prod is None:
+                continue
+            for label, group_name, field in resource_fields:
+                preview_group = cast(dict[str, dict[str, object]], getattr(preview, group_name))
+                production_group = cast(dict[str, dict[str, object]], getattr(prod, group_name))
+                for key, resource in preview_group.items():
+                    production_resource = production_group.get(key)
+                    if production_resource is not None and resource.get(field) == production_resource.get(field):
+                        raise ValidationError(
+                            f"preview {label} {preview.name}.{key} must not match its production {field}: "
+                            f"{resource.get(field)}"
+                        )
+
 def nested_dict(node: object, *path: str) -> object | None:
     current = node
     for segment in path:
@@ -431,6 +510,12 @@ def stringify_map(values: dict[str, object]) -> dict[str, str]:
     return {str(key): str(value) for key, value in values.items()}
 
 
+def includes_branch_scope(value: str, branch: str | None) -> bool:
+    if not branch:
+        return False
+    return branch in value or branch_slug(branch) in value
+
+
 def require_nonempty(value: object, label: str) -> None:
     if str(value or "") == "":
         raise ValidationError(f"{label} is required")
@@ -439,6 +524,16 @@ def require_nonempty(value: object, label: str) -> None:
 def require_file(path: Path) -> None:
     if not path.is_file():
         raise ValidationError(f"Required file not found: {path}")
+
+
+def require_within(path: Path, root: Path, label: str) -> Path:
+    resolved_root = root.resolve()
+    resolved_path = path.resolve()
+    try:
+        resolved_path.relative_to(resolved_root)
+    except ValueError as exc:
+        raise ValidationError(f"{label} must stay within {resolved_root}: {path}") from exc
+    return resolved_path
 
 
 def validate_python(path: Path) -> None:

--- a/src/md_blueprints/schema.py
+++ b/src/md_blueprints/schema.py
@@ -35,6 +35,8 @@ def load_yaml(path: Path) -> object:
             return yaml.safe_load(handle) or {}
     except yaml.YAMLError as exc:
         raise ValidationError(f"Invalid YAML in {path}: {exc}") from exc
+    except OSError as exc:
+        raise ValidationError(f"Could not read YAML file {path}: {exc}") from exc
 
 
 def declared_schema_version(data: object) -> int:

--- a/src/md_blueprints/template_repo/docs/blueprint-yml-reference.md
+++ b/src/md_blueprints/template_repo/docs/blueprint-yml-reference.md
@@ -33,6 +33,8 @@ resources:
 
 The `resources` object is required. Each resource group inside it is optional, so a blueprint can contain any combination of shares, Flights, Dives, and context resources.
 
+All resource `source` and `requirements` paths must resolve inside the blueprint package directory. Absolute paths, `..` traversal, and symlinks that escape the package are rejected so validation and deployment cannot read files from elsewhere on the runner.
+
 ## Rendering Model
 
 `blueprint.yml` is first validated as YAML and then rendered for a target such as `preview` or `prod`.
@@ -205,6 +207,7 @@ Rendered Flight validation:
 
 - `name`, `source`, and `requirements` must be non-empty after rendering.
 - `source` and `requirements` files must exist.
+- `source` and `requirements` must stay inside the blueprint package, including after resolving symlinks.
 - `source` must parse as valid Python.
 - Non-empty `scheduleCron` values must contain exactly 5 fields.
 - In the default preview target, schedules are disabled by policy and render as `""` even if the base Flight sets `scheduleCron`.

--- a/src/md_blueprints/template_repo/docs/repository-reference.md
+++ b/src/md_blueprints/template_repo/docs/repository-reference.md
@@ -30,6 +30,8 @@ context/
 
 `motherduck.yml` is the canonical repository manifest. It declares included blueprint manifests, shared variables, and the `preview` and `prod` targets. GitHub Actions discover changed blueprints from this manifest instead of requiring manual path-filter registration.
 
+`include` entries must be relative glob patterns that stay inside the repository root. Overlapping globs are deduplicated, and blueprint names must be unique across all matched manifests.
+
 The root manifest may also set `requiredCliVersion`, for example `requiredCliVersion: ">=1.3"`, when a repository depends on CLI behavior that cannot be expressed through schema shape alone.
 
 `md-blueprints` is the versioned CLI package that validates schemas, renders targets, plans deployments, deploys resources, cleans previews, and hosts migration commands.
@@ -99,6 +101,10 @@ The repo defines two targets:
 - `prod`: stable production names, protected by the `motherduck-production` GitHub Environment.
 
 Preview resources must include `${target.branch_slug}` in cleanup-sensitive share/database names. This prevents cleanup from dropping stable production resources.
+
+Preview Flight names and Dive titles must also contain either `${target.branch}` or `${target.branch_slug}`. Cleanup refuses any Flight, Dive, share, or database whose preview identifier is not branch-scoped or exactly matches its production identifier.
+
+The cleanup command also requires `targets.preview.policies.cleanup: true`; without that explicit opt-in it exits before querying or deleting resources.
 
 ## Local Commands
 

--- a/src/md_blueprints/template_repo/docs/tooling-and-schema-versioning.md
+++ b/src/md_blueprints/template_repo/docs/tooling-and-schema-versioning.md
@@ -103,10 +103,10 @@ Tagged `v*` pushes run the release workflow:
 2. Build the wheel and source distribution.
 3. Smoke test the installed wheel.
 4. Smoke test the local action wrapper.
-5. Attach artifacts to the matching GitHub Release.
+5. Verify the external PyPI and template-repository setup before publishing anything.
 6. Publish to PyPI through trusted publishing.
-7. Force-update the floating major tag, for example `v0`.
-8. Generate the customer template with the built wheel and force-push it to `motherduckdb/blueprints-template` when `BLUEPRINTS_TEMPLATE_PUSH_TOKEN` is configured.
+7. Generate the customer template with the built wheel and push it to `motherduckdb/blueprints-template`.
+8. Attach artifacts to the matching GitHub Release and only then update the floating major tag, for example `v0`.
 
 One-time PyPI setup: register the `md-blueprints` project and add a trusted publisher for this repository, `release.yaml`, and the `pypi` environment. Tagged releases run `scripts/check-release-external-setup.sh` before publishing so a missing project or trusted-publishing setup fails with an actionable error.
 

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -12,6 +12,17 @@ from md_blueprints.schema import ValidationError
 FIXTURES = Path(__file__).parent / "fixtures"
 
 
+def test_cleanup_respects_disabled_target_policy() -> None:
+    project = Project(FIXTURES / "simple")
+    preview = project.target_config("preview")
+    policies = preview["policies"]
+    assert isinstance(policies, dict)
+    policies["cleanup"] = False
+
+    with pytest.raises(ValidationError, match="cleanup is disabled"):
+        Deployer(project).cleanup_plan(target="preview", branch="feature/test", names=None)
+
+
 def test_cleanup_plan_refuses_share_without_branch_slug(monkeypatch: pytest.MonkeyPatch) -> None:
     deployer = Deployer(Project(FIXTURES / "complex"))
     monkeypatch.setattr(deployer, "_list_dive_ids", lambda title: [])
@@ -72,6 +83,47 @@ def test_cleanup_plan_refuses_database_without_branch_slug(monkeypatch: pytest.M
         ("database", "error"),
     ]
     assert "refusing to drop preview database without branch slug feature_branch" in records[1].notes
+    with pytest.raises(ValidationError, match="Plan contains errors"):
+        deployer.ensure_plan_succeeds(records)
+
+
+def test_cleanup_plan_refuses_flight_and_dive_names_that_match_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deployer = Deployer(Project(FIXTURES / "complex"))
+    monkeypatch.setattr(deployer, "_list_dive_ids", lambda title: pytest.fail("unsafe Dive lookup"))
+    monkeypatch.setattr(deployer, "_list_flight_ids", lambda name: pytest.fail("unsafe Flight lookup"))
+    preview = RenderedBlueprint(
+        name="ops",
+        title="Ops",
+        description="",
+        shares={},
+        flights={"loader": {"name": "production-loader"}},
+        dives={"dashboard": {"title": "Production Dashboard"}},
+        contexts={},
+    )
+    production = RenderedBlueprint(
+        name="ops",
+        title="Ops",
+        description="",
+        shares={},
+        flights={"loader": {"name": "production-loader"}},
+        dives={"dashboard": {"title": "Production Dashboard"}},
+        contexts={},
+    )
+
+    records = deployer._build_cleanup_plan(
+        [preview],
+        "prod",
+        branch="prod",
+        production={"ops": production},
+    )
+
+    assert [(record.type, record.action) for record in records] == [
+        ("dive", "error"),
+        ("flight", "error"),
+    ]
+    assert all("matches production" in record.notes for record in records)
     with pytest.raises(ValidationError, match="Plan contains errors"):
         deployer.ensure_plan_succeeds(records)
 
@@ -173,7 +225,11 @@ def test_flight_run_uses_named_motherduck_arguments(monkeypatch: pytest.MonkeyPa
 def test_cleanup_flight_delete_uses_named_motherduck_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
     deployer = Deployer(Project(FIXTURES / "complex"))
     calls: list[str] = []
-    monkeypatch.setattr(deployer, "_sql", lambda statement: calls.append(statement) or "")
+    def fake_sql(statement: str) -> str:
+        calls.append(statement)
+        return ""
+
+    monkeypatch.setattr(deployer, "_sql", fake_sql)
 
     deployer._apply_cleanup_plan(
         [

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -76,6 +76,19 @@ def test_init_force_overwrites_template_files(tmp_path: Path) -> None:
     assert "MotherDuck Blueprints" in (target / "README.md").read_text(encoding="utf-8")
 
 
+def test_init_force_refuses_symlink_that_escapes_target(tmp_path: Path) -> None:
+    target = tmp_path / "existing"
+    outside = tmp_path / "outside"
+    target.mkdir()
+    outside.mkdir()
+    (target / "docs").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValidationError, match="outside"):
+        run_init(target, force=True)
+
+    assert list(outside.iterdir()) == []
+
+
 def test_init_template_does_not_drift_from_mirrored_repo_paths(tmp_path: Path) -> None:
     target = tmp_path / "customer-blueprints"
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -5,10 +5,33 @@ from pathlib import Path
 import pytest
 
 import md_blueprints.project as project_module
+from md_blueprints.deploy import Deployer
 from md_blueprints.project import Project
+from md_blueprints.schema import ValidationError
 
 
 FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def write_root_manifest(root: Path, include: str = "blueprints/*/blueprint.yml") -> None:
+    (root / "motherduck.yml").write_text(
+        f"""
+schemaVersion: 1
+repository:
+  name: path-safety
+include:
+  - {include}
+targets:
+  preview:
+    mode: preview
+    policies:
+      cleanup: true
+      requireBranchSlugInDataResources: true
+  prod:
+    mode: production
+""".lstrip(),
+        encoding="utf-8",
+    )
 
 
 def test_changed_blueprints_zero_sha_returns_all_blueprints() -> None:
@@ -132,3 +155,112 @@ targets:
 
     monkeypatch.setattr(project_module, "run_command", lambda argv: "schemas/v1/blueprint.schema.json\n")
     assert project.changed_blueprints(base="main", head="HEAD") == ["first", "second"]
+
+
+def test_include_pattern_cannot_escape_project_root(tmp_path: Path) -> None:
+    write_root_manifest(tmp_path, "../*/blueprint.yml")
+
+    with pytest.raises(ValidationError, match="must stay within the project root"):
+        Project(tmp_path)
+
+
+def test_resource_source_cannot_escape_blueprint_package(tmp_path: Path) -> None:
+    blueprint_dir = tmp_path / "blueprints" / "unsafe"
+    blueprint_dir.mkdir(parents=True)
+    (tmp_path / "outside.tsx").write_text("export default function Dive() { return null; }\n", encoding="utf-8")
+    write_root_manifest(tmp_path)
+    (blueprint_dir / "blueprint.yml").write_text(
+        """
+schemaVersion: 1
+name: unsafe
+title: Unsafe
+resources:
+  dives:
+    dashboard:
+      title: Unsafe:${target.branch} (Preview)
+      source: ../../outside.tsx
+      requiredResources:
+        - url: md:_share/example/00000000-0000-0000-0000-000000000000
+          alias: example
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError, match="Dive source.*must stay within"):
+        Project(tmp_path).render_all("preview", branch="feature/test")
+
+
+def test_duplicate_blueprint_names_are_rejected(tmp_path: Path) -> None:
+    write_root_manifest(tmp_path)
+    for directory in ("first", "second"):
+        blueprint_dir = tmp_path / "blueprints" / directory
+        blueprint_dir.mkdir(parents=True)
+        (blueprint_dir / "blueprint.yml").write_text(
+            """
+schemaVersion: 1
+name: duplicate
+title: Duplicate
+resources: {}
+""".lstrip(),
+            encoding="utf-8",
+        )
+
+    with pytest.raises(ValidationError, match="Duplicate blueprint name 'duplicate'"):
+        Project(tmp_path)
+
+
+def test_live_preview_validates_the_requested_branch(tmp_path: Path) -> None:
+    blueprint_dir = tmp_path / "blueprints" / "branch-check"
+    blueprint_dir.mkdir(parents=True)
+    write_root_manifest(tmp_path)
+    (blueprint_dir / "blueprint.yml").write_text(
+        """
+schemaVersion: 1
+name: branch-check
+title: Branch Check
+resources:
+  shares:
+    data:
+      name: data_prod
+      database: data_prod
+      cleanup: true
+      dropDatabase: true
+      targets:
+        preview:
+          name: data_feature_mock_test
+          database: data_feature_mock_test
+""".lstrip(),
+        encoding="utf-8",
+    )
+    project = Project(tmp_path)
+    assert project.validate(targets=["preview"])
+
+    with pytest.raises(ValidationError, match="must include branch slug feature_actual"):
+        Deployer(project)._validate_and_render("preview", "feature/actual", None)
+
+
+def test_preview_resource_identifier_cannot_match_production(tmp_path: Path) -> None:
+    blueprint_dir = tmp_path / "blueprints" / "shared-name"
+    source_dir = blueprint_dir / "src"
+    source_dir.mkdir(parents=True)
+    (source_dir / "dive.tsx").write_text("export default function Dive() { return null; }\n", encoding="utf-8")
+    write_root_manifest(tmp_path)
+    (blueprint_dir / "blueprint.yml").write_text(
+        """
+schemaVersion: 1
+name: shared-name
+title: Shared Name
+resources:
+  dives:
+    dashboard:
+      title: production dashboard
+      source: src/dive.tsx
+      requiredResources:
+        - url: md:_share/example/00000000-0000-0000-0000-000000000000
+          alias: example
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError, match="must not match its production title"):
+        Project(tmp_path).validate(targets=["preview"], branch="prod")

--- a/tests/test_release_external_setup.py
+++ b/tests/test_release_external_setup.py
@@ -9,7 +9,21 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Iterator
 
+import yaml
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_release_publishes_only_after_external_preflight_and_publish_jobs() -> None:
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/release.yaml").read_text(encoding="utf-8"))
+    jobs = workflow["jobs"]
+
+    assert jobs["release-preflight"]["needs"] == "build"
+    assert "release-preflight" in jobs["publish-pypi"]["needs"]
+    assert "release-preflight" in jobs["publish-template"]["needs"]
+    assert set(jobs["finalize-release"]["needs"]) == {"publish-pypi", "publish-template"}
+    build_steps = {step.get("name") for step in jobs["build"]["steps"]}
+    assert "Publish GitHub Release" not in build_steps
 
 
 def test_release_external_check_accepts_existing_pypi_project(tmp_path: Path) -> None:


### PR DESCRIPTION
This PR closes the deployment, cleanup, filesystem, and release-safety gaps found during the repository audit while keeping the generated template and public guidance aligned.

### Codex description

- prevent preview operations from reusing or deleting production resources and validate the actual preview branch
- contain manifests, resource sources, and forced initialization writes within their intended filesystem boundaries
- reject duplicate blueprint names and surface YAML filesystem failures as validation errors
- sequence release publication after external preflight and narrow workflow permissions
- add regression tests, strict test typing, mirrored documentation, and changelog coverage
