### PR TITLE
fix: serialize preview cleanup

### DIFF
--- a/.github/workflows/cleanup_preview_blueprints.yaml
+++ b/.github/workflows/cleanup_preview_blueprints.yaml
@@ -9,6 +9,10 @@ on:
       - closed
   delete:
 
+concurrency:
+  group: cleanup-preview-${{ github.event.pull_request.head.ref || github.event.ref }}
+  cancel-in-progress: false
+
 jobs:
   cleanup:
     name: Delete Preview Blueprints for Branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Update this file in every pull request. Add entries under `Unreleased` until the
 
 ### Fixed
 
+- Serialized cleanup events per branch and made delete operations idempotent when another cleanup run removes a resource after planning.
 - Fixed the full test-suite mypy failure in the cleanup SQL regression test and added tests to the strict CI type-check.
 
 ## v0.3.0 - 2026-07-02

--- a/docs/repository-reference.md
+++ b/docs/repository-reference.md
@@ -149,7 +149,7 @@ For docs-only changes, run at least `git diff --check`. Run the full validation 
 - The `CI` workflow validates manifests, runs mock deployment tests, builds the included example Dive, and creates then destroys a generated starter blueprint.
 - Pull requests validate all manifests, discover changed blueprint packages from `motherduck.yml`, deploy the `preview` target, and comment with preview links.
 - Preview deployment runs a read-only plan immediately before deploy; the PR comment includes the plan and deployed links.
-- Preview cleanup runs when a PR closes or a branch is deleted. Dives are deleted before Flights, shares, and preview databases.
+- Preview cleanup runs when a PR closes or a branch is deleted. Cleanup events for the same branch are serialized, and already-removed resources are treated as success so simultaneous PR-close and branch-delete events remain idempotent. Dives are deleted before Flights, shares, and preview databases.
 - Pushes to `main` plan the `prod` target, write the plan to the GitHub job summary, then deploy through the protected `motherduck-production` environment.
 - No workflow file needs per-blueprint path filters or manual asset registration.
 

--- a/src/md_blueprints/deploy.py
+++ b/src/md_blueprints/deploy.py
@@ -635,20 +635,35 @@ class Deployer:
                 print(f"No preview Dive found for '{record.name}'")
             elif (record.type, record.action) == ("dive", "delete"):
                 print(f"Deleting preview Dive {record.id} ({record.name})")
-                self._sql(f"FROM MD_DELETE_DIVE(id='{record.id}'::UUID)")
+                self._delete_if_present(f"FROM MD_DELETE_DIVE(id='{record.id}'::UUID)", f"preview Dive {record.name}")
             elif (record.type, record.action) == ("flight", "missing"):
                 print(f"No preview Flight found for '{record.name}'")
             elif (record.type, record.action) == ("flight", "delete"):
                 print(f"Deleting preview Flight {record.id} ({record.name})")
-                self._sql(f"FROM MD_DELETE_FLIGHT(\"flight_id\" => '{record.id}'::UUID);")
+                self._delete_if_present(
+                    f"FROM MD_DELETE_FLIGHT(\"flight_id\" => '{record.id}'::UUID);",
+                    f"preview Flight {record.name}",
+                )
             elif (record.type, record.action) == ("share", "missing"):
                 print(f"No preview share found for '{record.name}'")
             elif (record.type, record.action) == ("share", "drop_share"):
                 print(f"Dropping preview share {record.name}")
-                self._sql(f"FROM MD_DROP_DATABASE_SHARE({sql_string(record.name)});")
+                self._delete_if_present(
+                    f"FROM MD_DROP_DATABASE_SHARE({sql_string(record.name)});",
+                    f"preview share {record.name}",
+                )
             elif (record.type, record.action) == ("database", "drop_database"):
                 print(f"Dropping preview database {record.name}")
                 self._sql(f"DROP DATABASE IF EXISTS {quote_ident(record.name)};")
+
+    def _delete_if_present(self, statement: str, label: str) -> None:
+        try:
+            self._sql(statement)
+        except CommandError as exc:
+            message = str(exc).lower()
+            if "does not exist" not in message and "not found" not in message:
+                raise
+            print(f"Skipping {label}; it was already removed by another cleanup run")
 
     def _list_flight_ids(self, name: str) -> list[str]:
         return [

--- a/src/md_blueprints/template_repo/.github/workflows/cleanup_preview_blueprints.yaml
+++ b/src/md_blueprints/template_repo/.github/workflows/cleanup_preview_blueprints.yaml
@@ -9,6 +9,10 @@ on:
       - closed
   delete:
 
+concurrency:
+  group: cleanup-preview-${{ github.event.pull_request.head.ref || github.event.ref }}
+  cancel-in-progress: false
+
 jobs:
   cleanup:
     name: Delete Preview Blueprints for Branch

--- a/src/md_blueprints/template_repo/docs/repository-reference.md
+++ b/src/md_blueprints/template_repo/docs/repository-reference.md
@@ -149,7 +149,7 @@ For docs-only changes, run at least `git diff --check`. Run the full validation 
 - The `CI` workflow validates manifests, runs mock deployment tests, builds the included example Dive, and creates then destroys a generated starter blueprint.
 - Pull requests validate all manifests, discover changed blueprint packages from `motherduck.yml`, deploy the `preview` target, and comment with preview links.
 - Preview deployment runs a read-only plan immediately before deploy; the PR comment includes the plan and deployed links.
-- Preview cleanup runs when a PR closes or a branch is deleted. Dives are deleted before Flights, shares, and preview databases.
+- Preview cleanup runs when a PR closes or a branch is deleted. Cleanup events for the same branch are serialized, and already-removed resources are treated as success so simultaneous PR-close and branch-delete events remain idempotent. Dives are deleted before Flights, shares, and preview databases.
 - Pushes to `main` plan the `prod` target, write the plan to the GitHub job summary, then deploy through the protected `motherduck-production` environment.
 - No workflow file needs per-blueprint path filters or manual asset registration.
 

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -248,6 +248,46 @@ def test_cleanup_flight_delete_uses_named_motherduck_arguments(monkeypatch: pyte
     assert calls == ['FROM MD_DELETE_FLIGHT("flight_id" => \'1a4ea2e6-0997-43ea-afe9-78c15c62220e\'::UUID);']
 
 
+def test_cleanup_ignores_resources_already_removed_by_concurrent_run(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    deployer = Deployer(Project(FIXTURES / "complex"))
+
+    def missing_share(statement: str) -> str:
+        raise CommandError('MotherDuck SQL failed: Share with name "preview_share" does not exist!')
+
+    monkeypatch.setattr(deployer, "_sql", missing_share)
+
+    deployer._apply_cleanup_plan(
+        [
+            PlanRecord(
+                blueprint="ops",
+                type="share",
+                key="data",
+                name="preview_share",
+                action="drop_share",
+                exists=True,
+                id="md:_share/example/id",
+            )
+        ]
+    )
+
+    assert "already removed by another cleanup run" in capsys.readouterr().out
+
+
+def test_cleanup_still_surfaces_unrelated_delete_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    deployer = Deployer(Project(FIXTURES / "complex"))
+
+    def permission_error(statement: str) -> str:
+        raise CommandError("MotherDuck SQL failed: permission denied")
+
+    monkeypatch.setattr(deployer, "_sql", permission_error)
+
+    with pytest.raises(CommandError, match="permission denied"):
+        deployer._delete_if_present("FROM delete_resource()", "preview resource")
+
+
 def test_sql_identifier_quoting_rejects_unsafe_database_names() -> None:
     assert quote_ident("preview_database_1") == '"preview_database_1"'
 


### PR DESCRIPTION
This follow-up makes preview cleanup safe when PR-close and branch-delete events fire for the same branch at nearly the same time.

### Codex description

- serialize cleanup workflow runs per preview branch
- treat resources removed by another cleanup run as an idempotent success
- preserve unrelated MotherDuck delete errors and add regression coverage
- keep generated-template workflow and cleanup documentation aligned