### PR TITLE
Add declarative Dive governance statuses

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,7 @@
 
 - [ ] New or renamed assets are declared in `blueprints/<name>/blueprint.yml`.
 - [ ] Dives list required resources in `blueprint.yml`.
+- [ ] Dive statuses are intentional: previews are `draft`, and `endorsed` production changes have an organization-admin reviewer.
 - [ ] Preview shares/databases that can be cleaned up include `${target.branch_slug}`.
 - [ ] Blueprints validate with `make validate`.
 - [ ] Dives build with `make preview-smoke <blueprint-name>` when changed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ Update this file in every pull request. Add entries under `Unreleased` until the
 
 ## Unreleased
 
+### Added
+
+- Added declarative Dive governance statuses (`draft`, `ready`, `endorsed`, and `archived`) with live status transitions in deployment plans, status reconciliation through `MD_UPDATE_DIVE_STATUS`, and backward-compatible preservation when production status is omitted.
+
 ### Changed
 
+- Enforced `draft` status for all preview Dives and made generated examples deploy production Dives as `ready`.
 - Hardened preview cleanup so Flights, Dives, shares, and databases must be branch-scoped, cannot reuse their production identifiers, and require an explicit target-policy opt-in.
 - Validated live preview operations with the requested branch instead of the validator's mock branch.
 - Restricted included manifests and resource source files to their repository and blueprint package boundaries, including after symlink resolution.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A blueprint is a small package that declares one data project — its [Flights](
 - **Merges to `main`** deploy stable production resources through a protected GitHub Environment.
 - **Branch cleanup** removes preview resources when the branch is deleted.
 
+Dive governance travels with the code: previews are always `draft`, while production manifests can declare `ready`, `endorsed`, or `archived`. Deployment plans show live-to-desired status transitions before anything changes.
+
 ## What's in this repository
 
 This repository is the source for the Blueprints tooling. As a user, you interact with three artifacts built from it:
@@ -108,6 +110,7 @@ Every pull request gets a comment with the deployment plan and preview links:
 
 - **Preview** deployments are branch-scoped: preview share and database names include the branch slug, Flight schedules are disabled, and resources are cleaned up when the branch goes away.
 - **Production** deployments run only from `main`, through the `motherduck-production` GitHub Environment, so you can require manual approval before anything changes.
+- **Dive status** is reconciled only when declared. Omitting it preserves the live status; setting `endorsed` requires an organization-admin deployment identity.
 
 ## Versioning and upgrades
 

--- a/blueprints/wikipedia-pageviews/blueprint.yml
+++ b/blueprints/wikipedia-pageviews/blueprint.yml
@@ -74,9 +74,11 @@ resources:
       title: Wikipedia Pageviews
       source: src/dive.tsx
       description: Recent daily pageviews for selected Wikipedia articles, loaded by a MotherDuck Flight from Wikimedia public data.
+      status: ready
       requiredResources:
         - share: pageviews
           alias: wikipedia_pageviews
       targets:
         preview:
           title: Wikipedia Pageviews:${target.branch} (Preview)
+          status: draft

--- a/docs/blueprint-yml-reference.md
+++ b/docs/blueprint-yml-reference.md
@@ -224,12 +224,14 @@ resources:
       title: Wikipedia Pageviews
       source: src/dive.tsx
       description: Recent daily pageviews.
+      status: ready
       requiredResources:
         - share: pageviews
           alias: wikipedia_pageviews
       targets:
         preview:
           title: Wikipedia Pageviews:${target.branch} (Preview)
+          status: draft
 ```
 
 Example using a direct share URL:
@@ -250,6 +252,7 @@ resources:
 | `resources.dives.<key>.title` | Yes | Non-empty string | None | MotherDuck Dive title after rendering. Must be unique per rendered target. |
 | `resources.dives.<key>.source` | Yes | Non-empty string | None | Path to the Dive source, relative to the blueprint directory. |
 | `resources.dives.<key>.description` | No | String | `""` | Dive description passed to MotherDuck. |
+| `resources.dives.<key>.status` | No | `draft`, `ready`, `endorsed`, or `archived` | Unmanaged | Desired MotherDuck governance status. When omitted, updates preserve the live status and new Dives use MotherDuck's `draft` default. |
 | `resources.dives.<key>.requiredResources` | Yes | Non-empty array | None | Share resources or direct share URLs that the Dive mounts. |
 | `resources.dives.<key>.targets` | No | Object keyed by target name | `{}` | Target-specific Dive overrides. |
 
@@ -257,10 +260,13 @@ Rendered Dive validation:
 
 - `title` and `source` must be non-empty after rendering.
 - `source` file must exist.
+- Preview Dives always render as `draft`; a non-draft preview override is rejected.
 - `requiredResources` must contain at least one item.
 - Each required resource must set `alias`.
 - Each required resource must set either `share` or `url`.
 - If `share` is set, it must reference a key under `resources.shares` in the same blueprint.
+
+Status is declarative only when it is present. Production deployments reconcile an explicit value with `MD_UPDATE_DIVE_STATUS`; plans show the current and desired values. Use `ready` for reviewed production Dives, reserve `endorsed` for intentionally rare organization-approved sources of truth, and use `archived` to retire a Dive without deleting its URL or history. Only MotherDuck organization admins can set `endorsed`, so a deployment that requests it must use an appropriately governed credential. Updating content without declaring `status` never resets or changes a live status.
 
 Required resource fields:
 

--- a/docs/examples/wikipedia-pageviews.md
+++ b/docs/examples/wikipedia-pageviews.md
@@ -6,7 +6,7 @@ This example is a self-contained blueprint in `blueprints/wikipedia-pageviews/`.
 
 - `resources.flights.pageviews_loader` - loads public Wikimedia pageview data into MotherDuck.
 - `resources.shares.pageviews` - names the database share produced by the Flight.
-- `resources.dives.pageviews` - reads from that share through the `wikipedia_pageviews` alias.
+- `resources.dives.pageviews` - reads from that share through the `wikipedia_pageviews` alias, using `draft` in preview and `ready` in production.
 
 The Flight creates these MotherDuck objects if they do not already exist:
 
@@ -41,13 +41,13 @@ On pull requests:
 5. The preview Flight name and Dive title include the branch name.
 6. The preview database and share include `${target.branch_slug}`.
 7. The Flight runs once, waits for success, waits for the share URL, and deploys the Dive.
-8. A PR comment lists the plan plus preview Flights, shares, and Dives.
+8. A PR comment lists the plan plus preview Flights, shares, and Draft Dives.
 
-On merge to `main`, production deployment writes a live plan to the GitHub job summary, runs through the protected `motherduck-production` environment, and uses stable names.
+On merge to `main`, production deployment writes a live plan to the GitHub job summary, runs through the protected `motherduck-production` environment, uses stable names, and promotes the Dive to `ready`.
 
 ## Preview Behavior
 
-The `preview` target disables schedules and requires cleanup-sensitive data resources to include the branch slug. The rendered preview share for branch `feature/mock-test` is:
+The `preview` target disables schedules, forces Dive status to `draft`, and requires cleanup-sensitive data resources to include the branch slug. The rendered preview share for branch `feature/mock-test` is:
 
 ```text
 wikipedia_pageviews_preview_feature_mock_test

--- a/docs/repository-reference.md
+++ b/docs/repository-reference.md
@@ -100,6 +100,8 @@ The repo defines two targets:
 - `preview`: branch-scoped resource names, schedules disabled, preview cleanup enabled.
 - `prod`: stable production names, protected by the `motherduck-production` GitHub Environment.
 
+Preview Dives always render with `draft` status. Production Dives may declare `draft`, `ready`, `endorsed`, or `archived`; omitted production status remains unmanaged and is preserved during content updates.
+
 Preview resources must include `${target.branch_slug}` in cleanup-sensitive share/database names. This prevents cleanup from dropping stable production resources.
 
 Preview Flight names and Dive titles must also contain either `${target.branch}` or `${target.branch_slug}`. Cleanup refuses any Flight, Dive, share, or database whose preview identifier is not branch-scoped or exactly matches its production identifier.
@@ -127,7 +129,7 @@ md-blueprints migrate --to latest
 
 `make preview-smoke <blueprint-name>` writes that blueprint's Dive into the local Vite preview harness and runs a production build without starting a server.
 
-`md-blueprints plan` validates and renders selected blueprints, queries live MotherDuck state with read-only SQL, and reports whether Flights and Dives will be created or updated. Shares are reported as `present` or `missing` because the deployer waits for shares but project Flight code creates them.
+`md-blueprints plan` validates and renders selected blueprints, queries live MotherDuck state with read-only SQL, and reports whether Flights and Dives will be created or updated. Dive rows include current and desired status, including endorsement or archival transitions. Shares are reported as `present` or `missing` because the deployer waits for shares but project Flight code creates them.
 
 `md-blueprints cleanup --dry-run` shows the preview Dives, Flights, shares, and databases that cleanup would delete or drop. It uses the same branch-slug safety checks as real cleanup and does not issue delete or drop queries.
 
@@ -151,6 +153,7 @@ For docs-only changes, run at least `git diff --check`. Run the full validation 
 - Preview deployment runs a read-only plan immediately before deploy; the PR comment includes the plan and deployed links.
 - Preview cleanup runs when a PR closes or a branch is deleted. Cleanup events for the same branch are serialized, and already-removed resources are treated as success so simultaneous PR-close and branch-delete events remain idempotent. Dives are deleted before Flights, shares, and preview databases.
 - Pushes to `main` plan the `prod` target, write the plan to the GitHub job summary, then deploy through the protected `motherduck-production` environment.
+- Setting a Dive to `endorsed` requires the production service account to be a MotherDuck organization admin. Keep that credential behind required environment reviewers and reserve endorsement for intentionally rare trusted sources of truth.
 - No workflow file needs per-blueprint path filters or manual asset registration.
 
 Customer repositories should pin the released package or action version. See [Tooling and Schema Versioning](tooling-and-schema-versioning.md) for the schema compatibility and migration policy.

--- a/docs/setup-your-repository.md
+++ b/docs/setup-your-repository.md
@@ -35,6 +35,8 @@ In your MotherDuck organization:
 
 Use a service account token rather than a personal token so deployed Dives, Flights, tables, and shares are owned by a shared automation identity.
 
+The normal service account can manage `draft`, `ready`, and `archived` on Dives it owns. Only an organization admin can set `endorsed`; if your blueprints declare that status, protect an admin-capable production token with required GitHub Environment reviewers. Do not grant admin merely to make every Dive endorsed.
+
 ## 3. Add GitHub Secrets
 
 In your repository:
@@ -107,7 +109,8 @@ Expected preview flow:
 5. Preview Flights run when `runOnDeploy` is true.
 6. Preview databases and shares are created with the branch slug.
 7. Dives deploy after required shares are resolvable.
-8. A PR comment lists the plan plus preview Flight, share, and Dive links.
+8. Preview Dives are enforced as `draft`.
+9. A PR comment lists the plan, Dive status, and preview Flight, share, and Dive links.
 
 ## 8. Verify Cleanup
 
@@ -140,7 +143,9 @@ Expected production flow:
 4. Production Flights deploy.
 5. Flights run when `runOnDeploy` is true.
 6. Required shares are resolved.
-7. Production Dives deploy.
+7. Production Dives deploy and reconcile an explicitly declared status.
+
+The generated examples use `ready` in production and `draft` in preview. Omitting production `status` preserves the live value. A plan that promotes a Dive to `endorsed` or moves an endorsed Dive to another status calls out that transition for the environment reviewer.
 
 ## 10. Customize the Blueprints
 

--- a/schemas/v1/blueprint.schema.json
+++ b/schemas/v1/blueprint.schema.json
@@ -113,6 +113,7 @@
         "title": { "type": "string", "minLength": 1 },
         "source": { "type": "string", "minLength": 1 },
         "description": { "type": "string" },
+        "status": { "type": "string", "enum": ["draft", "ready", "endorsed", "archived"] },
         "requiredResources": {
           "type": "array",
           "minItems": 1,

--- a/scripts/mock-test.sh
+++ b/scripts/mock-test.sh
@@ -27,6 +27,7 @@ state_dir="${MOCK_DUCKDB_STATE_DIR:?MOCK_DUCKDB_STATE_DIR is required}"
 flight_state="${state_dir}/flight_id"
 run_state="${state_dir}/run_number"
 dive_state="${state_dir}/dive_id"
+dive_status_state="${state_dir}/dive_status"
 share_url="md:_share/mock/00000000-0000-0000-0000-000000000003"
 run_status="${MOCK_FLIGHT_RUN_STATUS:-RUN_STATUS_SUCCEEDED}"
 
@@ -78,15 +79,27 @@ elif [[ "$query" == *"MD_LIST_DIVES"* ]]; then
     echo "00000000-0000-0000-0000-000000000021"
     echo "00000000-0000-0000-0000-000000000022"
   elif [ -f "$dive_state" ]; then
-    cat "$dive_state"
+    if [[ "$query" == *"SELECT id, status"* ]]; then
+      echo "$(cat "$dive_state"),$(cat "$dive_status_state")"
+    else
+      cat "$dive_state"
+    fi
   fi
 elif [[ "$query" == *"MD_CREATE_DIVE"* ]]; then
   echo "00000000-0000-0000-0000-000000000002" > "$dive_state"
+  echo "draft" > "$dive_status_state"
   cat "$dive_state"
+elif [[ "$query" == *"MD_UPDATE_DIVE_STATUS"* ]]; then
+  for status in draft ready endorsed archived; do
+    if [[ "$query" == *"'$status'"* ]]; then
+      echo "$status" > "$dive_status_state"
+    fi
+  done
 elif [[ "$query" == *"MD_UPDATE_DIVE"* ]]; then
   echo "00000000-0000-0000-0000-000000000002" > "$dive_state"
 elif [[ "$query" == *"MD_DELETE_DIVE"* ]]; then
   rm -f "$dive_state"
+  rm -f "$dive_status_state"
 else
   echo "Unexpected fake duckdb query: $query" >&2
   exit 1
@@ -123,6 +136,7 @@ class MockConnection:
         self.flight_state = self.state_dir / "flight_id"
         self.run_state = self.state_dir / "run_number"
         self.dive_state = self.state_dir / "dive_id"
+        self.dive_status_state = self.state_dir / "dive_status"
         self.share_url = "md:_share/mock/00000000-0000-0000-0000-000000000003"
 
     def execute(self, statement: str) -> MockResult:
@@ -180,16 +194,29 @@ class MockConnection:
                     ("00000000-0000-0000-0000-000000000022",),
                 ])
             if self.dive_state.exists():
+                if "SELECT id, status" in query:
+                    return MockResult([(
+                        self.dive_state.read_text().strip(),
+                        self.dive_status_state.read_text().strip(),
+                    )])
                 return MockResult([(self.dive_state.read_text().strip(),)])
             return MockResult([])
         if "MD_CREATE_DIVE" in query:
             self.dive_state.write_text("00000000-0000-0000-0000-000000000002", encoding="utf-8")
+            self.dive_status_state.write_text("draft", encoding="utf-8")
             return MockResult([(self.dive_state.read_text().strip(),)])
+        if "MD_UPDATE_DIVE_STATUS" in query:
+            for status in ("draft", "ready", "endorsed", "archived"):
+                if f"'{status}'" in query:
+                    self.dive_status_state.write_text(status, encoding="utf-8")
+                    break
+            return MockResult([])
         if "MD_UPDATE_DIVE" in query:
             self.dive_state.write_text("00000000-0000-0000-0000-000000000002", encoding="utf-8")
             return MockResult([])
         if "MD_DELETE_DIVE" in query:
             self.dive_state.unlink(missing_ok=True)
+            self.dive_status_state.unlink(missing_ok=True)
             return MockResult([])
 
         raise RuntimeError(f"Unexpected fake duckdb query: {query}")
@@ -297,6 +324,7 @@ echo "==> Rendering preview target"
 md-blueprints render --target preview --branch feature/mock-test --blueprints wikipedia-pageviews > "${TMP_DIR}/render.out"
 grep -q "wikipedia_pageviews_preview_feature_mock_test" "${TMP_DIR}/render.out"
 grep -q '"scheduleCron": ""' "${TMP_DIR}/render.out"
+grep -q '"status": "draft"' "${TMP_DIR}/render.out"
 
 echo "==> Planning preview target"
 : > "${TMP_DIR}/queries.log"
@@ -305,6 +333,7 @@ grep -q "#### Deployment Plan" "${TMP_DIR}/plan.out"
 grep -q "wikipedia-pageviews:feature/mock-test (Preview).*create" "${TMP_DIR}/plan.out"
 grep -q "wikipedia_pageviews_preview_feature_mock_test.*present" "${TMP_DIR}/plan.out"
 grep -q "Wikipedia Pageviews:feature/mock-test (Preview).*create" "${TMP_DIR}/plan.out"
+grep -q "Wikipedia Pageviews:feature/mock-test (Preview).*draft" "${TMP_DIR}/plan.out"
 if grep -Eq "MD_CREATE_|MD_UPDATE_|MD_DELETE_|MD_DROP_DATABASE_SHARE|DROP DATABASE" "${TMP_DIR}/queries.log"; then
   echo "Plan command issued a mutating query" >&2
   cat "${TMP_DIR}/queries.log" >&2
@@ -318,7 +347,10 @@ import json
 import sys
 
 records = json.loads(open(sys.argv[1]).read())
-required = {"blueprint", "type", "key", "name", "action", "exists", "id", "notes"}
+required = {
+    "blueprint", "type", "key", "name", "action", "exists", "id", "notes",
+    "current_status", "desired_status",
+}
 if not all(required <= set(row) for row in records):
     raise SystemExit("missing stable plan fields")
 if not any(row["type"] == "flight" and row["action"] == "create" for row in records):
@@ -376,6 +408,7 @@ grep -q "Updating existing flight 'wikipedia-pageviews:feature/mock-test (Previe
 
 echo "==> Mock deploying production blueprint"
 md-blueprints deploy --target prod --blueprints wikipedia-pageviews > "${TMP_DIR}/production.out"
+grep -q "MD_UPDATE_DIVE_STATUS.*'ready'" "${TMP_DIR}/queries.log"
 
 echo "==> Verifying empty access token is not sent"
 if grep -q "\"access_token_name\" => ''" "${TMP_DIR}/queries.log"; then

--- a/src/md_blueprints/deploy.py
+++ b/src/md_blueprints/deploy.py
@@ -66,6 +66,8 @@ class PlanRecord:
     exists: bool | None
     id: str | None
     notes: str = ""
+    current_status: str | None = None
+    desired_status: str | None = None
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -77,7 +79,22 @@ class PlanRecord:
             "exists": self.exists,
             "id": self.id,
             "notes": self.notes,
+            "current_status": self.current_status,
+            "desired_status": self.desired_status,
         }
+
+    def formatted_status(self) -> str:
+        if self.type != "dive":
+            return ""
+        if self.desired_status is None:
+            if self.current_status:
+                return f"preserve {self.current_status}"
+            return "draft (default)" if self.action == "create" else "unmanaged"
+        if self.current_status is None:
+            return self.desired_status
+        if self.current_status == self.desired_status:
+            return self.desired_status
+        return f"{self.current_status} -> {self.desired_status}"
 
 
 class PlanFormatter:
@@ -89,8 +106,8 @@ class PlanFormatter:
         lines = [
             f"#### {title}",
             "",
-            "| Blueprint | Type | Key | Name | Action | Exists | ID | Notes |",
-            "| --- | --- | --- | --- | --- | --- | --- | --- |",
+            "| Blueprint | Type | Key | Name | Action | Exists | ID | Status | Notes |",
+            "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
         ]
         for record in records:
             row = [
@@ -101,6 +118,7 @@ class PlanFormatter:
                 record.action,
                 PlanFormatter._format_exists(record.exists),
                 record.id or "",
+                record.formatted_status(),
                 record.notes,
             ]
             lines.append("| " + " | ".join(PlanFormatter._escape_cell(value) for value in row) + " |")
@@ -218,16 +236,7 @@ class Deployer:
                 )
 
             for key, dive in blueprint.dives.items():
-                records.append(
-                    self._existing_resource_record(
-                        blueprint=blueprint,
-                        type_name="dive",
-                        key=key,
-                        name=str(dive["title"]),
-                        ids=self._list_dive_ids(str(dive["title"])),
-                        duplicate_note="duplicate Dive title; expected 0 or 1",
-                    )
-                )
+                records.append(self._dive_plan_record(blueprint, key, dive))
 
             for key, ctx in blueprint.contexts.items():
                 records.append(
@@ -397,6 +406,62 @@ class Deployer:
             return PlanRecord(blueprint.name, type_name, key, name, "update", True, ids[0])
         return PlanRecord(blueprint.name, type_name, key, name, "error", True, ",".join(ids), duplicate_note)
 
+    def _dive_plan_record(
+        self,
+        blueprint: RenderedBlueprint,
+        key: str,
+        dive: dict[str, object],
+    ) -> PlanRecord:
+        title = str(dive["title"])
+        desired_status_value = dive.get("status")
+        desired_status = str(desired_status_value) if desired_status_value is not None else None
+        states = self._list_dive_states(title)
+        if not states:
+            notes = "endorsing requires an organization admin" if desired_status == "endorsed" else ""
+            return PlanRecord(
+                blueprint.name,
+                "dive",
+                key,
+                title,
+                "create",
+                False,
+                None,
+                notes,
+                desired_status=desired_status,
+            )
+        if len(states) == 1:
+            dive_id, current_status = states[0]
+            notes = ""
+            if current_status == "endorsed" and desired_status not in {None, "endorsed"}:
+                notes = "moving off endorsed may be one-way unless the deployer is an organization admin"
+            elif desired_status == "endorsed" and current_status != "endorsed":
+                notes = "endorsing requires an organization admin"
+            elif current_status == "endorsed":
+                notes = "content update remains endorsed"
+            return PlanRecord(
+                blueprint.name,
+                "dive",
+                key,
+                title,
+                "update",
+                True,
+                dive_id,
+                notes,
+                current_status=current_status,
+                desired_status=desired_status,
+            )
+        return PlanRecord(
+            blueprint.name,
+            "dive",
+            key,
+            title,
+            "error",
+            True,
+            ",".join(state[0] for state in states),
+            "duplicate Dive title; expected 0 or 1",
+            desired_status=desired_status,
+        )
+
     def _cleanup_record(
         self,
         blueprint: RenderedBlueprint,
@@ -451,7 +516,7 @@ class Deployer:
         print()
         self._print_section("Flights", "| Flight | ID | Run started |", "|--------|----|-------------|", flight_rows)
         self._print_section("Shares", "| Share | Link |", "|-------|------|", share_rows)
-        self._print_section("Dives", "| Dive | Link |", "|------|------|", dive_rows)
+        self._print_section("Dives", "| Dive | Status | Link |", "|------|--------|------|", dive_rows)
 
     def _print_section(self, title: str, header: str, separator: str, rows: list[str]) -> None:
         if not rows:
@@ -607,8 +672,25 @@ class Deployer:
         else:
             raise ValidationError(f"Cannot deploy Dive {title} with plan action {plan.action}")
 
+        desired_status_value = dive.get("status")
+        desired_status = str(desired_status_value) if desired_status_value is not None else None
+        if (
+            desired_status is not None
+            and desired_status != plan.current_status
+            and not (plan.action == "create" and desired_status == "draft")
+        ):
+            print(f"  Setting Dive status to {desired_status}...", file=sys.stderr)
+            self._sql(
+                f"FROM MD_UPDATE_DIVE_STATUS(id = '{dive_id}'::UUID, status = {sql_string(desired_status)});"
+            )
+
         print(f"  Deployed: https://app.motherduck.com/dives/{dive_id}", file=sys.stderr)
-        return f"| {title} | [Open Dive](https://app.motherduck.com/dives/{dive_id}) |" if target == "preview" else None
+        effective_status = desired_status or plan.current_status or "draft"
+        return (
+            f"| {title} | {effective_status} | [Open Dive](https://app.motherduck.com/dives/{dive_id}) |"
+            if target == "preview"
+            else None
+        )
 
     def _required_resources_sql(
         self,
@@ -681,6 +763,17 @@ class Deployer:
             for line in self._sql(f"SELECT id FROM MD_LIST_DIVES() WHERE title = {sql_string(title)}").splitlines()
             if line.strip()
         ]
+
+    def _list_dive_states(self, title: str) -> list[tuple[str, str | None]]:
+        states: list[tuple[str, str | None]] = []
+        output = self._sql(f"SELECT id, status FROM MD_LIST_DIVES() WHERE title = {sql_string(title)}")
+        for line in output.splitlines():
+            if not line.strip():
+                continue
+            dive_id, separator, raw_status = line.partition(",")
+            status = raw_status.strip().lower() if separator and raw_status.strip() else None
+            states.append((dive_id.strip(), status))
+        return states
 
     def _find_share_url(self, name: str) -> str:
         lines = self._sql(f"SELECT url FROM MD_LIST_DATABASE_SHARES() WHERE name = {sql_string(name)}").splitlines()

--- a/src/md_blueprints/project.py
+++ b/src/md_blueprints/project.py
@@ -12,6 +12,9 @@ from .schema import SchemaValidator, ValidationError, load_yaml, validate_requir
 from .template import Template
 
 
+DIVE_STATUSES = {"draft", "ready", "endorsed", "archived"}
+
+
 class CommandError(Exception):
     pass
 
@@ -309,6 +312,8 @@ class Project:
                 )
             )
             dive.setdefault("description", "")
+            if target == "preview":
+                dive.setdefault("status", "draft")
 
         contexts = self._render_resources(resources_node.get("context", {}), target, context)
         for ctx in contexts.values():
@@ -440,6 +445,13 @@ class Project:
                 require_nonempty(dive.get(field), f"dives.{key}.{field}")
             require_file(Path(str(dive["sourcePath"])))
             required_resources = dive.get("requiredResources")
+            status = dive.get("status")
+            if status is not None and status not in DIVE_STATUSES:
+                raise ValidationError(
+                    f"dives.{key}.status must be one of {', '.join(sorted(DIVE_STATUSES))}"
+                )
+            if target == "preview" and status != "draft":
+                raise ValidationError(f"preview Dive {blueprint.name}.{key} must use draft status")
             if (
                 target == "preview"
                 and not includes_branch_scope(str(dive["title"]), branch)

--- a/src/md_blueprints/schemas/v1/blueprint.schema.json
+++ b/src/md_blueprints/schemas/v1/blueprint.schema.json
@@ -113,6 +113,7 @@
         "title": { "type": "string", "minLength": 1 },
         "source": { "type": "string", "minLength": 1 },
         "description": { "type": "string" },
+        "status": { "type": "string", "enum": ["draft", "ready", "endorsed", "archived"] },
         "requiredResources": {
           "type": "array",
           "minItems": 1,

--- a/src/md_blueprints/template_repo/.github/pull_request_template.md
+++ b/src/md_blueprints/template_repo/.github/pull_request_template.md
@@ -11,6 +11,7 @@
 
 - [ ] New or renamed assets are declared in `blueprints/<name>/blueprint.yml`.
 - [ ] Dives list required resources in `blueprint.yml`.
+- [ ] Dive statuses are intentional: previews are `draft`, and `endorsed` production changes have an organization-admin reviewer.
 - [ ] Preview shares/databases that can be cleaned up include `${target.branch_slug}`.
 - [ ] Blueprints validate with `make validate`.
 - [ ] Dives build with `make preview-smoke <blueprint-name>` when changed.

--- a/src/md_blueprints/template_repo/README.md
+++ b/src/md_blueprints/template_repo/README.md
@@ -2,6 +2,8 @@
 
 This repository deploys MotherDuck [Flights](https://motherduck.com/docs/concepts/flights/), [Dives](https://motherduck.com/docs/key-tasks/ai-and-motherduck/dives/), [shares](https://motherduck.com/docs/key-tasks/sharing-data/sharing-overview/), and future context assets from GitHub. Pull requests validate blueprints, deploy branch-scoped previews, and leave a PR comment with the deployment plan and preview links. Merges to `main` deploy stable production resources through the `motherduck-production` GitHub Environment.
 
+Dive previews are always `draft`. Production blueprints can declare `ready`, `endorsed`, or `archived`, and deployment plans show status transitions before applying them. Omitting status preserves the current live value.
+
 If you are reading this in `motherduckdb/blueprints-template`, do not open pull requests there. That repository is generated from `motherduckdb/motherduck-blueprints` on each release, and direct edits are overwritten.
 
 ## Prerequisites

--- a/src/md_blueprints/template_repo/blueprints/wikipedia-pageviews/blueprint.yml
+++ b/src/md_blueprints/template_repo/blueprints/wikipedia-pageviews/blueprint.yml
@@ -74,9 +74,11 @@ resources:
       title: Wikipedia Pageviews
       source: src/dive.tsx
       description: Recent daily pageviews for selected Wikipedia articles, loaded by a MotherDuck Flight from Wikimedia public data.
+      status: ready
       requiredResources:
         - share: pageviews
           alias: wikipedia_pageviews
       targets:
         preview:
           title: Wikipedia Pageviews:${target.branch} (Preview)
+          status: draft

--- a/src/md_blueprints/template_repo/docs/blueprint-yml-reference.md
+++ b/src/md_blueprints/template_repo/docs/blueprint-yml-reference.md
@@ -224,12 +224,14 @@ resources:
       title: Wikipedia Pageviews
       source: src/dive.tsx
       description: Recent daily pageviews.
+      status: ready
       requiredResources:
         - share: pageviews
           alias: wikipedia_pageviews
       targets:
         preview:
           title: Wikipedia Pageviews:${target.branch} (Preview)
+          status: draft
 ```
 
 Example using a direct share URL:
@@ -250,6 +252,7 @@ resources:
 | `resources.dives.<key>.title` | Yes | Non-empty string | None | MotherDuck Dive title after rendering. Must be unique per rendered target. |
 | `resources.dives.<key>.source` | Yes | Non-empty string | None | Path to the Dive source, relative to the blueprint directory. |
 | `resources.dives.<key>.description` | No | String | `""` | Dive description passed to MotherDuck. |
+| `resources.dives.<key>.status` | No | `draft`, `ready`, `endorsed`, or `archived` | Unmanaged | Desired MotherDuck governance status. When omitted, updates preserve the live status and new Dives use MotherDuck's `draft` default. |
 | `resources.dives.<key>.requiredResources` | Yes | Non-empty array | None | Share resources or direct share URLs that the Dive mounts. |
 | `resources.dives.<key>.targets` | No | Object keyed by target name | `{}` | Target-specific Dive overrides. |
 
@@ -257,10 +260,13 @@ Rendered Dive validation:
 
 - `title` and `source` must be non-empty after rendering.
 - `source` file must exist.
+- Preview Dives always render as `draft`; a non-draft preview override is rejected.
 - `requiredResources` must contain at least one item.
 - Each required resource must set `alias`.
 - Each required resource must set either `share` or `url`.
 - If `share` is set, it must reference a key under `resources.shares` in the same blueprint.
+
+Status is declarative only when it is present. Production deployments reconcile an explicit value with `MD_UPDATE_DIVE_STATUS`; plans show the current and desired values. Use `ready` for reviewed production Dives, reserve `endorsed` for intentionally rare organization-approved sources of truth, and use `archived` to retire a Dive without deleting its URL or history. Only MotherDuck organization admins can set `endorsed`, so a deployment that requests it must use an appropriately governed credential. Updating content without declaring `status` never resets or changes a live status.
 
 Required resource fields:
 

--- a/src/md_blueprints/template_repo/docs/examples/wikipedia-pageviews.md
+++ b/src/md_blueprints/template_repo/docs/examples/wikipedia-pageviews.md
@@ -6,7 +6,7 @@ This example is a self-contained blueprint in `blueprints/wikipedia-pageviews/`.
 
 - `resources.flights.pageviews_loader` - loads public Wikimedia pageview data into MotherDuck.
 - `resources.shares.pageviews` - names the database share produced by the Flight.
-- `resources.dives.pageviews` - reads from that share through the `wikipedia_pageviews` alias.
+- `resources.dives.pageviews` - reads from that share through the `wikipedia_pageviews` alias, using `draft` in preview and `ready` in production.
 
 The Flight creates these MotherDuck objects if they do not already exist:
 
@@ -41,13 +41,13 @@ On pull requests:
 5. The preview Flight name and Dive title include the branch name.
 6. The preview database and share include `${target.branch_slug}`.
 7. The Flight runs once, waits for success, waits for the share URL, and deploys the Dive.
-8. A PR comment lists the plan plus preview Flights, shares, and Dives.
+8. A PR comment lists the plan plus preview Flights, shares, and Draft Dives.
 
-On merge to `main`, production deployment writes a live plan to the GitHub job summary, runs through the protected `motherduck-production` environment, and uses stable names.
+On merge to `main`, production deployment writes a live plan to the GitHub job summary, runs through the protected `motherduck-production` environment, uses stable names, and promotes the Dive to `ready`.
 
 ## Preview Behavior
 
-The `preview` target disables schedules and requires cleanup-sensitive data resources to include the branch slug. The rendered preview share for branch `feature/mock-test` is:
+The `preview` target disables schedules, forces Dive status to `draft`, and requires cleanup-sensitive data resources to include the branch slug. The rendered preview share for branch `feature/mock-test` is:
 
 ```text
 wikipedia_pageviews_preview_feature_mock_test

--- a/src/md_blueprints/template_repo/docs/repository-reference.md
+++ b/src/md_blueprints/template_repo/docs/repository-reference.md
@@ -100,6 +100,8 @@ The repo defines two targets:
 - `preview`: branch-scoped resource names, schedules disabled, preview cleanup enabled.
 - `prod`: stable production names, protected by the `motherduck-production` GitHub Environment.
 
+Preview Dives always render with `draft` status. Production Dives may declare `draft`, `ready`, `endorsed`, or `archived`; omitted production status remains unmanaged and is preserved during content updates.
+
 Preview resources must include `${target.branch_slug}` in cleanup-sensitive share/database names. This prevents cleanup from dropping stable production resources.
 
 Preview Flight names and Dive titles must also contain either `${target.branch}` or `${target.branch_slug}`. Cleanup refuses any Flight, Dive, share, or database whose preview identifier is not branch-scoped or exactly matches its production identifier.
@@ -127,7 +129,7 @@ md-blueprints migrate --to latest
 
 `make preview-smoke <blueprint-name>` writes that blueprint's Dive into the local Vite preview harness and runs a production build without starting a server.
 
-`md-blueprints plan` validates and renders selected blueprints, queries live MotherDuck state with read-only SQL, and reports whether Flights and Dives will be created or updated. Shares are reported as `present` or `missing` because the deployer waits for shares but project Flight code creates them.
+`md-blueprints plan` validates and renders selected blueprints, queries live MotherDuck state with read-only SQL, and reports whether Flights and Dives will be created or updated. Dive rows include current and desired status, including endorsement or archival transitions. Shares are reported as `present` or `missing` because the deployer waits for shares but project Flight code creates them.
 
 `md-blueprints cleanup --dry-run` shows the preview Dives, Flights, shares, and databases that cleanup would delete or drop. It uses the same branch-slug safety checks as real cleanup and does not issue delete or drop queries.
 
@@ -151,6 +153,7 @@ For docs-only changes, run at least `git diff --check`. Run the full validation 
 - Preview deployment runs a read-only plan immediately before deploy; the PR comment includes the plan and deployed links.
 - Preview cleanup runs when a PR closes or a branch is deleted. Cleanup events for the same branch are serialized, and already-removed resources are treated as success so simultaneous PR-close and branch-delete events remain idempotent. Dives are deleted before Flights, shares, and preview databases.
 - Pushes to `main` plan the `prod` target, write the plan to the GitHub job summary, then deploy through the protected `motherduck-production` environment.
+- Setting a Dive to `endorsed` requires the production service account to be a MotherDuck organization admin. Keep that credential behind required environment reviewers and reserve endorsement for intentionally rare trusted sources of truth.
 - No workflow file needs per-blueprint path filters or manual asset registration.
 
 Customer repositories should pin the released package or action version. See [Tooling and Schema Versioning](tooling-and-schema-versioning.md) for the schema compatibility and migration policy.

--- a/src/md_blueprints/template_repo/docs/setup-your-repository.md
+++ b/src/md_blueprints/template_repo/docs/setup-your-repository.md
@@ -35,6 +35,8 @@ In your MotherDuck organization:
 
 Use a service account token rather than a personal token so deployed Dives, Flights, tables, and shares are owned by a shared automation identity.
 
+The normal service account can manage `draft`, `ready`, and `archived` on Dives it owns. Only an organization admin can set `endorsed`; if your blueprints declare that status, protect an admin-capable production token with required GitHub Environment reviewers. Do not grant admin merely to make every Dive endorsed.
+
 ## 3. Add GitHub Secrets
 
 In your repository:
@@ -107,7 +109,8 @@ Expected preview flow:
 5. Preview Flights run when `runOnDeploy` is true.
 6. Preview databases and shares are created with the branch slug.
 7. Dives deploy after required shares are resolvable.
-8. A PR comment lists the plan plus preview Flight, share, and Dive links.
+8. Preview Dives are enforced as `draft`.
+9. A PR comment lists the plan, Dive status, and preview Flight, share, and Dive links.
 
 ## 8. Verify Cleanup
 
@@ -140,7 +143,9 @@ Expected production flow:
 4. Production Flights deploy.
 5. Flights run when `runOnDeploy` is true.
 6. Required shares are resolved.
-7. Production Dives deploy.
+7. Production Dives deploy and reconcile an explicitly declared status.
+
+The generated examples use `ready` in production and `draft` in preview. Omitting production `status` preserves the live value. A plan that promotes a Dive to `endorsed` or moves an endorsed Dive to another status calls out that transition for the environment reviewer.
 
 ## 10. Customize the Blueprints
 

--- a/src/md_blueprints/template_repo/schemas/v1/blueprint.schema.json
+++ b/src/md_blueprints/template_repo/schemas/v1/blueprint.schema.json
@@ -113,6 +113,7 @@
         "title": { "type": "string", "minLength": 1 },
         "source": { "type": "string", "minLength": 1 },
         "description": { "type": "string" },
+        "status": { "type": "string", "enum": ["draft", "ready", "endorsed", "archived"] },
         "requiredResources": {
           "type": "array",
           "minItems": 1,

--- a/src/md_blueprints/template_repo/templates/blueprint/README.md
+++ b/src/md_blueprints/template_repo/templates/blueprint/README.md
@@ -8,6 +8,8 @@ This generated blueprint is a complete starter project. It deploys a Flight that
 - Share: `data`
 - Dive: `dashboard`
 
+The Dive deploys as `draft` in pull-request previews and `ready` in production. Change the production status to `endorsed` only when an organization admin has approved it as a trusted source of truth; use `archived` to retire it without deleting its URL and history.
+
 The production target writes to the stable `__DATABASE_NAME__` database and share. The preview target writes to `__DATABASE_NAME___preview_${target.branch_slug}`, disables schedules, runs once on deploy, and cleans up the preview share and database when the branch closes.
 
 ## Replace the Starter Logic

--- a/src/md_blueprints/template_repo/templates/blueprint/blueprint.yml
+++ b/src/md_blueprints/template_repo/templates/blueprint/blueprint.yml
@@ -53,9 +53,11 @@ resources:
     dashboard:
       title: __BLUEPRINT_NAME__
       source: src/dive.tsx
+      status: ready
       requiredResources:
         - share: data
           alias: __DATABASE_NAME__
       targets:
         preview:
           title: __BLUEPRINT_NAME__:${target.branch} (Preview)
+          status: draft

--- a/templates/blueprint/README.md
+++ b/templates/blueprint/README.md
@@ -8,6 +8,8 @@ This generated blueprint is a complete starter project. It deploys a Flight that
 - Share: `data`
 - Dive: `dashboard`
 
+The Dive deploys as `draft` in pull-request previews and `ready` in production. Change the production status to `endorsed` only when an organization admin has approved it as a trusted source of truth; use `archived` to retire it without deleting its URL and history.
+
 The production target writes to the stable `__DATABASE_NAME__` database and share. The preview target writes to `__DATABASE_NAME___preview_${target.branch_slug}`, disables schedules, runs once on deploy, and cleans up the preview share and database when the branch closes.
 
 ## Replace the Starter Logic

--- a/templates/blueprint/blueprint.yml
+++ b/templates/blueprint/blueprint.yml
@@ -53,9 +53,11 @@ resources:
     dashboard:
       title: __BLUEPRINT_NAME__
       source: src/dive.tsx
+      status: ready
       requiredResources:
         - share: data
           alias: __DATABASE_NAME__
       targets:
         preview:
           title: __BLUEPRINT_NAME__:${target.branch} (Preview)
+          status: draft

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -134,7 +134,7 @@ def test_deploy_plan_is_idempotent_for_same_live_state(monkeypatch: pytest.Monke
     rendered = project.render_all("prod")
 
     monkeypatch.setattr(deployer, "_list_flight_ids", lambda name: [f"{name}-id"])
-    monkeypatch.setattr(deployer, "_list_dive_ids", lambda title: [f"{title}-id"])
+    monkeypatch.setattr(deployer, "_list_dive_states", lambda title: [(f"{title}-id", "ready")])
     monkeypatch.setattr(deployer, "_find_share_url", lambda name: f"md:_share/{name}/123")
 
     first = [record.to_dict() for record in deployer._build_deploy_plan(rendered)]
@@ -143,6 +143,105 @@ def test_deploy_plan_is_idempotent_for_same_live_state(monkeypatch: pytest.Monke
     assert first == second
     assert {record["action"] for record in first if record["type"] in {"flight", "dive"}} == {"update"}
     assert {record["action"] for record in first if record["type"] == "share"} == {"present"}
+
+
+def test_dive_plan_reports_status_transition(monkeypatch: pytest.MonkeyPatch) -> None:
+    project = Project(FIXTURES / "simple")
+    deployer = Deployer(project)
+    blueprint = project.render_all("preview", branch="feature/status")[0]
+    monkeypatch.setattr(
+        deployer,
+        "_list_dive_states",
+        lambda title: [("00000000-0000-0000-0000-000000000002", "ready")],
+    )
+
+    record = deployer._build_deploy_plan([blueprint])[0]
+
+    assert record.current_status == "ready"
+    assert record.desired_status == "draft"
+    assert record.formatted_status() == "ready -> draft"
+
+
+def test_new_unmanaged_dive_plan_reports_motherduck_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    project = Project(FIXTURES / "simple")
+    deployer = Deployer(project)
+    blueprint = project.render_all("prod")[0]
+    monkeypatch.setattr(deployer, "_list_dive_states", lambda title: [])
+
+    record = deployer._build_deploy_plan([blueprint])[0]
+
+    assert record.formatted_status() == "draft (default)"
+
+
+def test_dive_deploy_updates_explicit_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    deployer = Deployer(Project(FIXTURES / "simple"))
+    calls: list[str] = []
+
+    def fake_sql(statement: str) -> str:
+        calls.append(statement)
+        return ""
+
+    monkeypatch.setattr(deployer, "_sql", fake_sql)
+    deployer._deploy_dive(
+        {
+            "title": "Production Dashboard",
+            "sourcePath": "src/dive.tsx",
+            "description": "",
+            "requiredResources": [{"url": "md:_share/example/id", "alias": "example"}],
+            "status": "ready",
+        },
+        {},
+        "prod",
+        PlanRecord(
+            blueprint="simple-dive",
+            type="dive",
+            key="example",
+            name="Production Dashboard",
+            action="update",
+            exists=True,
+            id="00000000-0000-0000-0000-000000000002",
+            current_status="draft",
+            desired_status="ready",
+        ),
+    )
+
+    assert any("MD_UPDATE_DIVE_CONTENT" in call for call in calls)
+    assert any("MD_UPDATE_DIVE_STATUS" in call and "'ready'" in call for call in calls)
+
+
+def test_dive_deploy_preserves_status_when_unmanaged(monkeypatch: pytest.MonkeyPatch) -> None:
+    deployer = Deployer(Project(FIXTURES / "simple"))
+    calls: list[str] = []
+
+    def fake_sql(statement: str) -> str:
+        calls.append(statement)
+        return ""
+
+    monkeypatch.setattr(deployer, "_sql", fake_sql)
+
+    deployer._deploy_dive(
+        {
+            "title": "Production Dashboard",
+            "sourcePath": "src/dive.tsx",
+            "description": "",
+            "requiredResources": [{"url": "md:_share/example/id", "alias": "example"}],
+        },
+        {},
+        "prod",
+        PlanRecord(
+            blueprint="simple-dive",
+            type="dive",
+            key="example",
+            name="Production Dashboard",
+            action="update",
+            exists=True,
+            id="00000000-0000-0000-0000-000000000002",
+            current_status="endorsed",
+            desired_status=None,
+        ),
+    )
+
+    assert not any("MD_UPDATE_DIVE_STATUS" in call for call in calls)
 
 
 def test_flight_update_retries_without_schedule_when_existing_flight_is_unscheduled(

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -264,3 +264,72 @@ resources:
 
     with pytest.raises(ValidationError, match="must not match its production title"):
         Project(tmp_path).validate(targets=["preview"], branch="prod")
+
+
+def test_preview_dive_defaults_to_draft_without_managing_production_status() -> None:
+    project = Project(FIXTURES / "simple")
+
+    preview = project.render_all("preview", branch="feature/status")[0]
+    production = project.render_all("prod")[0]
+
+    assert preview.dives["example"]["status"] == "draft"
+    assert "status" not in production.dives["example"]
+
+
+def test_preview_dive_rejects_non_draft_target_override(tmp_path: Path) -> None:
+    blueprint_dir = tmp_path / "blueprints" / "unsafe-status"
+    source_dir = blueprint_dir / "src"
+    source_dir.mkdir(parents=True)
+    (source_dir / "dive.tsx").write_text("export default function Dive() { return null; }\n", encoding="utf-8")
+    write_root_manifest(tmp_path)
+    (blueprint_dir / "blueprint.yml").write_text(
+        """
+schemaVersion: 1
+name: unsafe-status
+title: Unsafe Status
+resources:
+  dives:
+    dashboard:
+      title: Unsafe Status
+      source: src/dive.tsx
+      status: ready
+      requiredResources:
+        - url: md:_share/example/00000000-0000-0000-0000-000000000000
+          alias: example
+      targets:
+        preview:
+          title: Unsafe Status:${target.branch} (Preview)
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError, match="must use draft status"):
+        Project(tmp_path).validate(targets=["preview"], branch="feature/status")
+
+
+def test_dive_status_rejects_unknown_value(tmp_path: Path) -> None:
+    blueprint_dir = tmp_path / "blueprints" / "unknown-status"
+    source_dir = blueprint_dir / "src"
+    source_dir.mkdir(parents=True)
+    (source_dir / "dive.tsx").write_text("export default function Dive() { return null; }\n", encoding="utf-8")
+    write_root_manifest(tmp_path)
+    (blueprint_dir / "blueprint.yml").write_text(
+        """
+schemaVersion: 1
+name: unknown-status
+title: Unknown Status
+resources:
+  dives:
+    dashboard:
+      title: Unknown Status
+      source: src/dive.tsx
+      status: trusted
+      requiredResources:
+        - url: md:_share/example/00000000-0000-0000-0000-000000000000
+          alias: example
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError, match="must be one of"):
+        Project(tmp_path)


### PR DESCRIPTION
## Summary

- Add optional Dive status support for draft, ready, endorsed, and archived.
- Enforce Draft for preview Dives while preserving existing production status when status is omitted.
- Show current and desired Dive status in deployment plans and reconcile explicit changes with MD_UPDATE_DIVE_STATUS.
- Update the Wikipedia example and generated starter to use Draft in previews and Ready in production.
- Document the organization-admin requirement and review warnings for Endorsed transitions.

## Compatibility and governance

- Existing blueprints without production status keep their live Dive status.
- New unmanaged Dives retain the MotherDuck Draft default.
- Content-only updates to Endorsed Dives preserve endorsement and are identified in the plan.
- Endorsing a Dive requires an organization-admin deployment identity protected by production approvals.

## Verification

- 50 Python tests passed.
- Strict mypy passed for src/md_blueprints and tests.
- make validate passed.
- make mock-test passed, including preview Draft and production Ready behavior.
- make package-smoke passed.
- Schema and generated-template mirrors are synchronized.