### PR TITLE
docs: add guides-as-code and ncs project workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Update this file in every pull request. Add entries under `Unreleased` until the
 
 ## Unreleased
 
+### Added
+
+- Added an end-to-end Guides-as-code how-to covering scaffolding, branch-scoped previews, access, references, planning, deployment, and troubleshooting.
+- Added a project-pattern walkthrough for the NCS Field Recovery Explorer.
+
+### Changed
+
+- Expanded the root, repository, setup, Guide package, and generated-template documentation to surface Guide deployment and the NCS public-data example.
+
 ## v0.4.0 - 2026-07-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -96,6 +96,15 @@ Use `make new-project revenue-overview` when a Flight and Dive genuinely preview
 
 Guide packages can publish versioned Markdown with catalog, Dive, Flight, and Guide references. Role packages and share grants provide declarative RBAC; admin-only operations run a capability preflight before any mutation.
 
+Create a Guide package and validate it without publishing:
+
+```bash
+make new-guide revenue-metrics
+make validate
+```
+
+When the content is ready, follow [Manage Guides as code](docs/guides-as-code.md) to enable deployment, add branch-scoped previews, and attach resource references.
+
 Once a MotherDuck token is configured, you can inspect live create/update/delete actions before applying them:
 
 ```bash
@@ -150,9 +159,10 @@ make install-deploy
 
 - [Repository Reference](docs/repository-reference.md): layout, targets, local commands, CI/CD, and context-layer notes.
 - [blueprint.yml Reference](docs/blueprint-yml-reference.md): complete field reference for blueprint manifests.
+- [Manage Guides as code](docs/guides-as-code.md): scaffold, preview, reference, and deploy version-controlled Guides.
 - [Tooling and Schema Versioning](docs/tooling-and-schema-versioning.md): CLI/action pinning, schema compatibility, and migrations.
 - [Wikipedia Pageviews example](docs/examples/wikipedia-pageviews.md): the end-to-end example blueprint.
-- [NCS Field Recovery Explorer](projects/ncs-field-recovery/README.md): a complete public-data project with a Flight, share, and Dive.
+- [NCS Field Recovery Explorer](docs/examples/ncs-field-recovery.md): a complete public-data project with a Flight, share, and Dive.
 - [MotherDuck documentation](https://motherduck.com/docs/getting-started) and the [MotherDuck Community Slack](https://slack.motherduck.com/) for product questions and support.
 
 ## Contributing

--- a/docs/blueprint-yml-reference.md
+++ b/docs/blueprint-yml-reference.md
@@ -208,6 +208,8 @@ Catalog references require exactly one of `url`, `share`, or `input`, and may na
 
 `resources.context` retains its validation-only compatibility behavior; `md-blueprints doctor` recommends `resources.guides`.
 
+For a complete scaffold-to-deployment workflow, see [Manage Guides as code](guides-as-code.md).
+
 ## Roles
 
 ```yaml

--- a/docs/examples/ncs-field-recovery.md
+++ b/docs/examples/ncs-field-recovery.md
@@ -1,0 +1,82 @@
+# NCS Field Recovery Explorer
+
+The NCS Field Recovery Explorer is a complete project package that loads public Norwegian Continental Shelf data, publishes a share, and deploys an interactive Dive. It demonstrates when related resources belong together below `projects/` instead of in independently deployed typed packages.
+
+The implementation lives in [`projects/ncs-field-recovery/`](../../projects/ncs-field-recovery/).
+
+## What the project deploys
+
+```text
+projects/ncs-field-recovery/
+  blueprint.yml
+  src/
+    flight.py
+    requirements.txt
+    dive.tsx
+```
+
+The manifest owns three resources:
+
+- `loader`: an unscheduled Flight that loads official SODIR FactMaps data and runs on deploy.
+- `data`: a share over the loaded database.
+- `explorer`: a Dive that reads the share and compares official field recovery estimates.
+
+Because the resources share one lifecycle, preview and production selection treat them as one package. `waitForRun: success` also prevents the Dive from resolving its share until the ingestion run succeeds.
+
+## Why this is a project package
+
+Use `projects/` when changing one resource should preview, deploy, and roll back the complete set. The NCS example has that ownership boundary:
+
+1. The Flight creates the tables and analytical view expected by the Dive.
+2. The share publishes that database.
+3. The Dive queries the shared view.
+
+The split [Wikipedia Pageviews example](wikipedia-pageviews.md) shows the alternative: a Flight producer and Dive consumer with independent lifecycles connected through an output and input.
+
+## Validate the example
+
+Run the repository checks without contacting MotherDuck:
+
+```bash
+make validate
+make mock-test
+make example-smoke
+```
+
+Build the local Dive preview without starting a development server:
+
+```bash
+make preview-smoke ncs-field-recovery
+```
+
+## Deploy a branch-scoped preview
+
+With `MOTHERDUCK_TOKEN` configured, inspect the live plan before deployment:
+
+```bash
+make install-deploy
+.venv/bin/md-blueprints plan \
+  --target preview \
+  --branch feature/ncs-review \
+  --blueprints ncs-field-recovery
+```
+
+Opening a pull request runs the same selection through GitHub Actions. Preview database, share, Flight, and Dive names include the branch scope, and cleanup removes them after the branch closes. The production target uses stable names and runs through the protected `motherduck-production` environment.
+
+## Reuse the pattern
+
+Start a co-owned package with:
+
+```bash
+make new-project field-analytics
+```
+
+Then carry over the patterns that fit your project:
+
+- Use target variables for stable production names and branch-scoped preview names.
+- Set `runOnDeploy: true` when a deployment needs fresh data.
+- Set `waitForRun: success` when downstream resources must wait for the Flight.
+- Keep source-specific metric definitions and limitations in the package README.
+- Use an output and input instead of a project package when the producer and consumer need independent owners or release schedules.
+
+See the [project README](../../projects/ncs-field-recovery/README.md) for source provenance, metric definitions, tables, and the transformation-only smoke path.

--- a/docs/guides-as-code.md
+++ b/docs/guides-as-code.md
@@ -1,0 +1,150 @@
+# Manage Guides as code
+
+Use a Guide package when your team wants metric definitions, query conventions, and domain knowledge to follow the same review and deployment workflow as application code. A deployed Guide keeps its Markdown content, metadata, access, and references in MotherDuck aligned with `blueprint.yml`.
+
+This workflow requires `md-blueprints >=0.4.0`. Organization-wide Guides require an admin deployment identity.
+
+## 1. Scaffold a Guide package
+
+Create a package below the typed `guides/` root:
+
+```bash
+make new-guide revenue-metrics
+```
+
+The command creates:
+
+```text
+guides/revenue-metrics/
+  blueprint.yml
+  guide.md
+  README.md
+```
+
+The generated manifest uses `deploy: false`, so `make validate` checks the Guide source without publishing it. This is useful while the Guide is still being reviewed.
+
+## 2. Write the Guide
+
+Keep one subject area in each Guide. Put the rules an agent must follow near the top, include working SQL patterns, and call out known pitfalls.
+
+````markdown
+# Revenue metrics
+
+## Rules
+
+- Use `analytics.main.subscriptions` for recurring revenue.
+- Exclude rows where `is_test_account` is true.
+- Calculate MRR from the normalized monthly amount, not invoice totals.
+
+## Query pattern
+
+```sql
+SELECT month, sum(monthly_amount) AS mrr
+FROM analytics.main.subscriptions
+WHERE NOT is_test_account
+GROUP BY month
+ORDER BY month;
+```
+````
+
+Do not include tokens, credentials, personal data, or source excerpts that should not be shared with everyone who can read the Guide.
+
+## 3. Configure deployment and references
+
+Set `deploy: true` when the repository should own the Guide lifecycle. The following package attaches the Guide to a table in an existing MotherDuck database and keeps previews private:
+
+```yaml
+schemaVersion: 1
+name: revenue-metrics
+title: Revenue metrics
+description: Canonical recurring-revenue definitions.
+
+resources:
+  guides:
+    guide:
+      title: Revenue metrics
+      topic: finance/revenue
+      source: guide.md
+      description: Definitions and query rules for recurring revenue.
+      access: organization
+      deploy: true
+      changeComment: Synchronize the reviewed revenue definitions.
+      references:
+        - type: catalog
+          url: md:analytics
+          schema: main
+          table: subscriptions
+          description: Canonical recurring-revenue source.
+      targets:
+        preview:
+          title: Revenue metrics:${target.branch} (Preview)
+          access: user
+```
+
+Preview Guide titles or topics must include `${target.branch}` or `${target.branch_slug}`. Preview Guides cannot use a production `id`; Blueprints discovers each preview by its rendered topic and title and removes it when the branch closes.
+
+Production deployment matches an existing Guide by `id` when configured, or by the exact topic and title otherwise. Set `id` only when adopting a specific existing production Guide or when topic and title are not unique. When the production resource has an `id`, set `targets.preview.id: null` so the preview gets its own identity.
+
+## 4. Add resource references
+
+References help agents discover the Guide while exploring the resources it documents. A Guide can reference:
+
+- A catalog object from a package-local `share`, a repository `input`, or a literal share `url`.
+- A Dive, Flight, or Guide by stable `uuid`.
+- A Dive, Flight, or Guide resource in this repository by `resource`, with `blueprint` when it lives in another package.
+
+When the referenced resources exist in the same repository, reference a Dive and a Guide in their packages:
+
+```yaml
+references:
+  - type: dive
+    blueprint: revenue-dashboard
+    resource: dashboard
+  - type: guide
+    blueprint: data-governance
+    resource: metric-ownership
+```
+
+Blueprints resolves all repository references during planning and fails before mutation if a target is missing or ambiguous. Guide references also participate in dependency ordering, and reference cycles fail validation.
+
+See the [Guide manifest reference](blueprint-yml-reference.md#guides) for every field and reference selector.
+
+## 5. Validate and review the plan
+
+Validate both preview and production rendering without contacting MotherDuck:
+
+```bash
+make validate
+```
+
+With the target's MotherDuck token environment variable configured, install the live deployment dependencies and inspect the preview plan:
+
+```bash
+make install-deploy
+.venv/bin/md-blueprints plan \
+  --target preview \
+  --branch feature/revenue-guide \
+  --blueprints revenue-metrics
+```
+
+The plan reports `validated_only`, `create`, `update`, or an actionable error for each Guide. It also verifies that referenced live resources resolve before deployment starts.
+
+## 6. Deploy through GitHub
+
+Push the branch and open a pull request. The generated workflow:
+
+1. Detects the changed Guide package.
+2. Includes connected producers and consumers in the preview selection.
+3. Deploys the branch-scoped preview after its references resolve.
+4. Adds the Guide ID and deployment plan to the pull request comment.
+5. Deletes the preview Guide when the pull request closes or the branch is deleted.
+
+After review, merge the pull request. The production workflow publishes stable Guide content, references, metadata, and access through the protected `motherduck-production` environment.
+
+## Troubleshooting
+
+- **The plan says `validated_only`.** Set `deploy: true` after the Guide is ready to publish.
+- **Preview validation rejects the title.** Add `${target.branch}` or `${target.branch_slug}` to the preview title or topic.
+- **The deployment requires the admin role.** Use an admin service account for `access: organization`, or use `access: user` to keep the Guide private to the deployment identity.
+- **The plan finds duplicate Guides.** Set the existing production Guide's UUID as `id` and set `targets.preview.id: null`.
+- **A reference does not resolve.** Check the `blueprint` and `resource` keys, or use the live resource's `uuid` for an externally managed Dive, Flight, or Guide.

--- a/docs/repository-reference.md
+++ b/docs/repository-reference.md
@@ -149,6 +149,8 @@ Preview Dives always use `draft`. Production manifests can declare `draft`, `rea
 
 Declare Guide assets with `resources.guides`. They remain source-validation-only by default; `deploy: true` enables create, version, metadata, access, reference, and preview-cleanup lifecycle management. Organization-wide Guides require an admin deployment identity. `resources.context` remains accepted for validation-only compatibility; `md-blueprints doctor` recommends the new name.
 
+See [Manage Guides as code](guides-as-code.md) for the end-to-end workflow, including branch-scoped previews and repository resource references.
+
 ## RBAC
 
 Declare custom roles under `resources.roles` or scaffold a role package with `make new-role`. Roles deploy only in production, before resources that may grant access to them. Share `grants` can target roles and users in additive or authoritative mode. Role and organization-Guide changes run an admin capability preflight before the first mutation.
@@ -156,3 +158,8 @@ Declare custom roles under `resources.roles` or scaffold a role package with `ma
 ## CI/CD
 
 Pull requests compute directly changed packages, expand the preview dependency graph, plan live changes, deploy branch-scoped resources, and comment with plans and preview links. Pushes to `main` expand production changes downstream and deploy through the protected production environment. Closing a PR or deleting a branch triggers dependency-safe preview cleanup.
+
+## Included examples
+
+- [Wikipedia Pageviews](examples/wikipedia-pageviews.md) uses independent Flight and Dive packages connected through a named output and input.
+- [NCS Field Recovery Explorer](examples/ncs-field-recovery.md) keeps its Flight, share, and Dive in one project because they deploy and roll back together.

--- a/docs/setup-your-repository.md
+++ b/docs/setup-your-repository.md
@@ -158,7 +158,7 @@ You can then:
 - Connect same-repository packages through `outputs` and `inputs`; use literal share URLs for external repositories.
 - Replace the bundled Wikipedia and NCS public-data examples with your own packages.
 - Add target `deployment.tokenEnvVar` and `deployment.identity` metadata in `motherduck.yml` if preview and production use different service account secrets.
-- Publish versioned Guide assets below `guides/` with `resources.guides` and `deploy: true`.
+- Publish versioned Guide assets below `guides/` with `resources.guides` and `deploy: true`; follow [Manage Guides as code](guides-as-code.md) for preview naming, access, and references.
 - Manage custom roles below `roles/` with `resources.roles`; use `mode: authoritative` only when the repository owns the complete membership set.
 - Update `.github/CODEOWNERS`.
 

--- a/guides/README.md
+++ b/guides/README.md
@@ -3,3 +3,28 @@
 Place version-controlled Guides below this root. Guides default to validation-only for backward compatibility; set `deploy: true` to create and version them in MotherDuck.
 
 Use `access: user` for the deployment identity or `access: organization` for organization-wide access. Organization Guides require an admin deployment identity. References may point at catalog objects, Dives, Flights, or other Guides.
+
+Create a package with:
+
+```bash
+make new-guide revenue-metrics
+```
+
+The generated package keeps `deploy: false` until its content is ready to publish. When enabling deployment, add a branch-scoped preview title or topic:
+
+```yaml
+resources:
+  guides:
+    guide:
+      title: Revenue metrics
+      topic: finance/revenue
+      source: guide.md
+      access: organization
+      deploy: true
+      targets:
+        preview:
+          title: Revenue metrics:${target.branch} (Preview)
+          access: user
+```
+
+Read [Manage Guides as code](../docs/guides-as-code.md) for the complete workflow and [blueprint.yml Reference](../docs/blueprint-yml-reference.md#guides) for all Guide and reference fields.

--- a/src/md_blueprints/template_repo/README.md
+++ b/src/md_blueprints/template_repo/README.md
@@ -59,6 +59,15 @@ Use `make new-project revenue-overview` when several resources genuinely ship to
 
 Guide packages can publish versioned Markdown with catalog and resource references. Role packages and share grants provide declarative RBAC; admin-only operations run a capability preflight before mutation.
 
+Create a Guide package and validate it without publishing:
+
+```bash
+make new-guide revenue-metrics
+make validate
+```
+
+When the content is ready, follow [Manage Guides as code](docs/guides-as-code.md) to enable deployment, add branch-scoped previews, and attach resource references.
+
 When you have a MotherDuck token configured, inspect live create/update/delete actions before applying them:
 
 ```bash
@@ -97,6 +106,7 @@ Compatible minor and patch releases move the floating action major and are valid
 
 - [Repository Reference](docs/repository-reference.md): layout, targets, local commands, CI/CD, and context-layer notes.
 - [blueprint.yml Reference](docs/blueprint-yml-reference.md): complete field reference for blueprint manifests.
+- [Manage Guides as code](docs/guides-as-code.md): scaffold, preview, reference, and deploy version-controlled Guides.
 - [Tooling and Schema Versioning](docs/tooling-and-schema-versioning.md): CLI/action pinning, schema compatibility, and migrations.
 - [Wikipedia Pageviews example](docs/examples/wikipedia-pageviews.md): a Flight that loads public data, publishes a share, and deploys a Dive that reads that share.
-- [NCS Field Recovery Explorer](projects/ncs-field-recovery/README.md): a complete public-data project with a Flight, share, and Dive.
+- [NCS Field Recovery Explorer](docs/examples/ncs-field-recovery.md): a complete public-data project with a Flight, share, and Dive.

--- a/src/md_blueprints/template_repo/docs/blueprint-yml-reference.md
+++ b/src/md_blueprints/template_repo/docs/blueprint-yml-reference.md
@@ -208,6 +208,8 @@ Catalog references require exactly one of `url`, `share`, or `input`, and may na
 
 `resources.context` retains its validation-only compatibility behavior; `md-blueprints doctor` recommends `resources.guides`.
 
+For a complete scaffold-to-deployment workflow, see [Manage Guides as code](guides-as-code.md).
+
 ## Roles
 
 ```yaml

--- a/src/md_blueprints/template_repo/docs/examples/ncs-field-recovery.md
+++ b/src/md_blueprints/template_repo/docs/examples/ncs-field-recovery.md
@@ -1,0 +1,82 @@
+# NCS Field Recovery Explorer
+
+The NCS Field Recovery Explorer is a complete project package that loads public Norwegian Continental Shelf data, publishes a share, and deploys an interactive Dive. It demonstrates when related resources belong together below `projects/` instead of in independently deployed typed packages.
+
+The implementation lives in [`projects/ncs-field-recovery/`](../../projects/ncs-field-recovery/).
+
+## What the project deploys
+
+```text
+projects/ncs-field-recovery/
+  blueprint.yml
+  src/
+    flight.py
+    requirements.txt
+    dive.tsx
+```
+
+The manifest owns three resources:
+
+- `loader`: an unscheduled Flight that loads official SODIR FactMaps data and runs on deploy.
+- `data`: a share over the loaded database.
+- `explorer`: a Dive that reads the share and compares official field recovery estimates.
+
+Because the resources share one lifecycle, preview and production selection treat them as one package. `waitForRun: success` also prevents the Dive from resolving its share until the ingestion run succeeds.
+
+## Why this is a project package
+
+Use `projects/` when changing one resource should preview, deploy, and roll back the complete set. The NCS example has that ownership boundary:
+
+1. The Flight creates the tables and analytical view expected by the Dive.
+2. The share publishes that database.
+3. The Dive queries the shared view.
+
+The split [Wikipedia Pageviews example](wikipedia-pageviews.md) shows the alternative: a Flight producer and Dive consumer with independent lifecycles connected through an output and input.
+
+## Validate the example
+
+Run the repository checks without contacting MotherDuck:
+
+```bash
+make validate
+make mock-test
+make example-smoke
+```
+
+Build the local Dive preview without starting a development server:
+
+```bash
+make preview-smoke ncs-field-recovery
+```
+
+## Deploy a branch-scoped preview
+
+With `MOTHERDUCK_TOKEN` configured, inspect the live plan before deployment:
+
+```bash
+make install-deploy
+.venv/bin/md-blueprints plan \
+  --target preview \
+  --branch feature/ncs-review \
+  --blueprints ncs-field-recovery
+```
+
+Opening a pull request runs the same selection through GitHub Actions. Preview database, share, Flight, and Dive names include the branch scope, and cleanup removes them after the branch closes. The production target uses stable names and runs through the protected `motherduck-production` environment.
+
+## Reuse the pattern
+
+Start a co-owned package with:
+
+```bash
+make new-project field-analytics
+```
+
+Then carry over the patterns that fit your project:
+
+- Use target variables for stable production names and branch-scoped preview names.
+- Set `runOnDeploy: true` when a deployment needs fresh data.
+- Set `waitForRun: success` when downstream resources must wait for the Flight.
+- Keep source-specific metric definitions and limitations in the package README.
+- Use an output and input instead of a project package when the producer and consumer need independent owners or release schedules.
+
+See the [project README](../../projects/ncs-field-recovery/README.md) for source provenance, metric definitions, tables, and the transformation-only smoke path.

--- a/src/md_blueprints/template_repo/docs/guides-as-code.md
+++ b/src/md_blueprints/template_repo/docs/guides-as-code.md
@@ -1,0 +1,150 @@
+# Manage Guides as code
+
+Use a Guide package when your team wants metric definitions, query conventions, and domain knowledge to follow the same review and deployment workflow as application code. A deployed Guide keeps its Markdown content, metadata, access, and references in MotherDuck aligned with `blueprint.yml`.
+
+This workflow requires `md-blueprints >=0.4.0`. Organization-wide Guides require an admin deployment identity.
+
+## 1. Scaffold a Guide package
+
+Create a package below the typed `guides/` root:
+
+```bash
+make new-guide revenue-metrics
+```
+
+The command creates:
+
+```text
+guides/revenue-metrics/
+  blueprint.yml
+  guide.md
+  README.md
+```
+
+The generated manifest uses `deploy: false`, so `make validate` checks the Guide source without publishing it. This is useful while the Guide is still being reviewed.
+
+## 2. Write the Guide
+
+Keep one subject area in each Guide. Put the rules an agent must follow near the top, include working SQL patterns, and call out known pitfalls.
+
+````markdown
+# Revenue metrics
+
+## Rules
+
+- Use `analytics.main.subscriptions` for recurring revenue.
+- Exclude rows where `is_test_account` is true.
+- Calculate MRR from the normalized monthly amount, not invoice totals.
+
+## Query pattern
+
+```sql
+SELECT month, sum(monthly_amount) AS mrr
+FROM analytics.main.subscriptions
+WHERE NOT is_test_account
+GROUP BY month
+ORDER BY month;
+```
+````
+
+Do not include tokens, credentials, personal data, or source excerpts that should not be shared with everyone who can read the Guide.
+
+## 3. Configure deployment and references
+
+Set `deploy: true` when the repository should own the Guide lifecycle. The following package attaches the Guide to a table in an existing MotherDuck database and keeps previews private:
+
+```yaml
+schemaVersion: 1
+name: revenue-metrics
+title: Revenue metrics
+description: Canonical recurring-revenue definitions.
+
+resources:
+  guides:
+    guide:
+      title: Revenue metrics
+      topic: finance/revenue
+      source: guide.md
+      description: Definitions and query rules for recurring revenue.
+      access: organization
+      deploy: true
+      changeComment: Synchronize the reviewed revenue definitions.
+      references:
+        - type: catalog
+          url: md:analytics
+          schema: main
+          table: subscriptions
+          description: Canonical recurring-revenue source.
+      targets:
+        preview:
+          title: Revenue metrics:${target.branch} (Preview)
+          access: user
+```
+
+Preview Guide titles or topics must include `${target.branch}` or `${target.branch_slug}`. Preview Guides cannot use a production `id`; Blueprints discovers each preview by its rendered topic and title and removes it when the branch closes.
+
+Production deployment matches an existing Guide by `id` when configured, or by the exact topic and title otherwise. Set `id` only when adopting a specific existing production Guide or when topic and title are not unique. When the production resource has an `id`, set `targets.preview.id: null` so the preview gets its own identity.
+
+## 4. Add resource references
+
+References help agents discover the Guide while exploring the resources it documents. A Guide can reference:
+
+- A catalog object from a package-local `share`, a repository `input`, or a literal share `url`.
+- A Dive, Flight, or Guide by stable `uuid`.
+- A Dive, Flight, or Guide resource in this repository by `resource`, with `blueprint` when it lives in another package.
+
+When the referenced resources exist in the same repository, reference a Dive and a Guide in their packages:
+
+```yaml
+references:
+  - type: dive
+    blueprint: revenue-dashboard
+    resource: dashboard
+  - type: guide
+    blueprint: data-governance
+    resource: metric-ownership
+```
+
+Blueprints resolves all repository references during planning and fails before mutation if a target is missing or ambiguous. Guide references also participate in dependency ordering, and reference cycles fail validation.
+
+See the [Guide manifest reference](blueprint-yml-reference.md#guides) for every field and reference selector.
+
+## 5. Validate and review the plan
+
+Validate both preview and production rendering without contacting MotherDuck:
+
+```bash
+make validate
+```
+
+With the target's MotherDuck token environment variable configured, install the live deployment dependencies and inspect the preview plan:
+
+```bash
+make install-deploy
+.venv/bin/md-blueprints plan \
+  --target preview \
+  --branch feature/revenue-guide \
+  --blueprints revenue-metrics
+```
+
+The plan reports `validated_only`, `create`, `update`, or an actionable error for each Guide. It also verifies that referenced live resources resolve before deployment starts.
+
+## 6. Deploy through GitHub
+
+Push the branch and open a pull request. The generated workflow:
+
+1. Detects the changed Guide package.
+2. Includes connected producers and consumers in the preview selection.
+3. Deploys the branch-scoped preview after its references resolve.
+4. Adds the Guide ID and deployment plan to the pull request comment.
+5. Deletes the preview Guide when the pull request closes or the branch is deleted.
+
+After review, merge the pull request. The production workflow publishes stable Guide content, references, metadata, and access through the protected `motherduck-production` environment.
+
+## Troubleshooting
+
+- **The plan says `validated_only`.** Set `deploy: true` after the Guide is ready to publish.
+- **Preview validation rejects the title.** Add `${target.branch}` or `${target.branch_slug}` to the preview title or topic.
+- **The deployment requires the admin role.** Use an admin service account for `access: organization`, or use `access: user` to keep the Guide private to the deployment identity.
+- **The plan finds duplicate Guides.** Set the existing production Guide's UUID as `id` and set `targets.preview.id: null`.
+- **A reference does not resolve.** Check the `blueprint` and `resource` keys, or use the live resource's `uuid` for an externally managed Dive, Flight, or Guide.

--- a/src/md_blueprints/template_repo/docs/repository-reference.md
+++ b/src/md_blueprints/template_repo/docs/repository-reference.md
@@ -149,6 +149,8 @@ Preview Dives always use `draft`. Production manifests can declare `draft`, `rea
 
 Declare Guide assets with `resources.guides`. They remain source-validation-only by default; `deploy: true` enables create, version, metadata, access, reference, and preview-cleanup lifecycle management. Organization-wide Guides require an admin deployment identity. `resources.context` remains accepted for validation-only compatibility; `md-blueprints doctor` recommends the new name.
 
+See [Manage Guides as code](guides-as-code.md) for the end-to-end workflow, including branch-scoped previews and repository resource references.
+
 ## RBAC
 
 Declare custom roles under `resources.roles` or scaffold a role package with `make new-role`. Roles deploy only in production, before resources that may grant access to them. Share `grants` can target roles and users in additive or authoritative mode. Role and organization-Guide changes run an admin capability preflight before the first mutation.
@@ -156,3 +158,8 @@ Declare custom roles under `resources.roles` or scaffold a role package with `ma
 ## CI/CD
 
 Pull requests compute directly changed packages, expand the preview dependency graph, plan live changes, deploy branch-scoped resources, and comment with plans and preview links. Pushes to `main` expand production changes downstream and deploy through the protected production environment. Closing a PR or deleting a branch triggers dependency-safe preview cleanup.
+
+## Included examples
+
+- [Wikipedia Pageviews](examples/wikipedia-pageviews.md) uses independent Flight and Dive packages connected through a named output and input.
+- [NCS Field Recovery Explorer](examples/ncs-field-recovery.md) keeps its Flight, share, and Dive in one project because they deploy and roll back together.

--- a/src/md_blueprints/template_repo/docs/setup-your-repository.md
+++ b/src/md_blueprints/template_repo/docs/setup-your-repository.md
@@ -158,7 +158,7 @@ You can then:
 - Connect same-repository packages through `outputs` and `inputs`; use literal share URLs for external repositories.
 - Replace the bundled Wikipedia and NCS public-data examples with your own packages.
 - Add target `deployment.tokenEnvVar` and `deployment.identity` metadata in `motherduck.yml` if preview and production use different service account secrets.
-- Publish versioned Guide assets below `guides/` with `resources.guides` and `deploy: true`.
+- Publish versioned Guide assets below `guides/` with `resources.guides` and `deploy: true`; follow [Manage Guides as code](guides-as-code.md) for preview naming, access, and references.
 - Manage custom roles below `roles/` with `resources.roles`; use `mode: authoritative` only when the repository owns the complete membership set.
 - Update `.github/CODEOWNERS`.
 

--- a/src/md_blueprints/template_repo/guides/README.md
+++ b/src/md_blueprints/template_repo/guides/README.md
@@ -3,3 +3,28 @@
 Place version-controlled Guides below this root. Guides default to validation-only for backward compatibility; set `deploy: true` to create and version them in MotherDuck.
 
 Use `access: user` for the deployment identity or `access: organization` for organization-wide access. Organization Guides require an admin deployment identity. References may point at catalog objects, Dives, Flights, or other Guides.
+
+Create a package with:
+
+```bash
+make new-guide revenue-metrics
+```
+
+The generated package keeps `deploy: false` until its content is ready to publish. When enabling deployment, add a branch-scoped preview title or topic:
+
+```yaml
+resources:
+  guides:
+    guide:
+      title: Revenue metrics
+      topic: finance/revenue
+      source: guide.md
+      access: organization
+      deploy: true
+      targets:
+        preview:
+          title: Revenue metrics:${target.branch} (Preview)
+          access: user
+```
+
+Read [Manage Guides as code](../docs/guides-as-code.md) for the complete workflow and [blueprint.yml Reference](../docs/blueprint-yml-reference.md#guides) for all Guide and reference fields.


### PR DESCRIPTION
## Why

Guide deployment and the NCS Field Recovery Explorer are supported in the repository, but users have to piece together the end-to-end workflows from terse reference material and package files. This adds task-focused documentation while keeping field-level details in the existing reference pages.

## What changed

- add a Guides-as-code workflow covering scaffolding, validation-only mode, branch-scoped previews, access, references, planning, deployment, cleanup, and troubleshooting
- add an NCS Field Recovery Explorer walkthrough that explains the combined project lifecycle and contrasts it with the split Wikipedia producer/consumer example
- surface both additions from the root README, repository/setup references, and the Guides package README
- mirror the new and updated docs into the generated customer-repository template
- record the documentation changes in the changelog

## Why this structure

The new pages are goal-oriented guides. The existing blueprint reference remains the authoritative field and compatibility reference, while package READMEs keep source-specific implementation details. Mirroring the pages into the packaged template makes the same guidance available in generated repositories.

## Validation

- make validate
- python -m pytest (95 passed)
- python -m mypy --strict src/md_blueprints tests
- make mock-test
- make example-smoke
- make package-smoke
- make preview-smoke ncs-field-recovery
- markdownlint on repository and generated-template docs
- local Markdown link validation
- documented Guide manifest schema validation