### PR TITLE
fix(scaffold): harden generated blueprint edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ Update this file in every pull request. Add entries under `Unreleased` until the
 
 ### Fixed
 
+- Made all typed scaffolds emit YAML-safe strings for reserved slugs and aliases, derive valid SQL aliases for numeric-leading blueprint names, normalize external-share URLs, and reject explicitly empty aliases.
+- Rejected duplicate blueprint names across typed roots and command options that do not apply to the selected scaffold kind before writing files.
+- Made `new project` use the complete canonical starter manifest and README instead of a reduced duplicate implementation.
 - Made the NCS field ingestion transactional, collision-safe across concurrent runs, and covered by source pagination, transformation, and rollback tests.
 - Improved the NCS Field Recovery Dive's mobile layout, keyboard focus, toggle state, loading/error announcements, chart description, and table semantics.
 - Made update checks reject only newer releases instead of treating an unreleased local version as outdated, and made the scheduled doctor close resolved upgrade issues.

--- a/scripts/package-smoke-test.sh
+++ b/scripts/package-smoke-test.sh
@@ -59,6 +59,30 @@ fi
 "$INSTALL_VENV/bin/md-blueprints" migrate --root "$REPO_ROOT" --to latest
 "$INSTALL_VENV/bin/md-blueprints" init "$TMP_DIR/generated-template"
 "$INSTALL_VENV/bin/md-blueprints" validate --root "$TMP_DIR/generated-template"
+
+echo "==> Exercising installed scaffold commands"
+"$INSTALL_VENV/bin/md-blueprints" new flight true --root "$TMP_DIR/generated-template"
+"$INSTALL_VENV/bin/md-blueprints" new dive 1-wheel-dashboard \
+  --root "$TMP_DIR/generated-template" \
+  --input true.data
+"$INSTALL_VENV/bin/md-blueprints" new dive external-wheel-dashboard \
+  --root "$TMP_DIR/generated-template" \
+  --url "  md:_share/example/00000000-0000-0000-0000-000000000000  " \
+  --alias off
+"$INSTALL_VENV/bin/md-blueprints" new guide null --root "$TMP_DIR/generated-template"
+"$INSTALL_VENV/bin/md-blueprints" new role on --root "$TMP_DIR/generated-template"
+"$INSTALL_VENV/bin/md-blueprints" new project 123 --root "$TMP_DIR/generated-template"
+"$INSTALL_VENV/bin/md-blueprints" validate --root "$TMP_DIR/generated-template"
+"$INSTALL_VENV/bin/md-blueprints" render \
+  --root "$TMP_DIR/generated-template" \
+  --target preview \
+  --branch feature/package-smoke \
+  --blueprints 123 > "$TMP_DIR/generated-project-render.json"
+grep -q "_123_preview_feature_package_smoke" "$TMP_DIR/generated-project-render.json"
+grep -q '"alias": "_123"' "$TMP_DIR/generated-project-render.json"
+grep -q 'url: "md:_share/example/00000000-0000-0000-0000-000000000000"' \
+  "$TMP_DIR/generated-template/dives/external-wheel-dashboard/blueprint.yml"
+
 grep -q "CLI_VERSION := ${CLI_VERSION}" "$TMP_DIR/generated-template/Makefile"
 grep -Fq 'CLI_SOURCE := git+https://github.com/motherduckdb/motherduck-blueprints.git@v$(CLI_VERSION)' "$TMP_DIR/generated-template/Makefile"
 grep -Fq 'installed_version="$$( [ -x "$(CLI)" ] && "$(CLI)" --version' "$TMP_DIR/generated-template/Makefile"

--- a/scripts/scaffold-smoke-test.sh
+++ b/scripts/scaffold-smoke-test.sh
@@ -29,7 +29,21 @@ echo "==> Creating generated blueprint example"
 make -C "$SCAFFOLD_ROOT" new-blueprint "$EXAMPLE_NAME"
 test -f "$SCAFFOLD_ROOT/projects/$EXAMPLE_NAME/README.md"
 
-if grep -R "__BLUEPRINT_NAME__\|__DATABASE_NAME__" "$SCAFFOLD_ROOT/projects/$EXAMPLE_NAME"; then
+echo "==> Creating typed and edge-case blueprint examples"
+make -C "$SCAFFOLD_ROOT" new-flight true
+make -C "$SCAFFOLD_ROOT" new-dive 1-dashboard INPUT=true.data
+make -C "$SCAFFOLD_ROOT" new-guide on
+make -C "$SCAFFOLD_ROOT" new-role null
+make -C "$SCAFFOLD_ROOT" new-project 123
+
+if grep -R \
+  "__BLUEPRINT_NAME__\|__BLUEPRINT_TITLE__\|__DATABASE_NAME__" \
+  "$SCAFFOLD_ROOT/projects/$EXAMPLE_NAME" \
+  "$SCAFFOLD_ROOT/flights/true" \
+  "$SCAFFOLD_ROOT/dives/1-dashboard" \
+  "$SCAFFOLD_ROOT/guides/on" \
+  "$SCAFFOLD_ROOT/roles/null" \
+  "$SCAFFOLD_ROOT/projects/123"; then
   echo "Generated blueprint still contains template placeholders" >&2
   exit 1
 fi
@@ -44,6 +58,13 @@ make -C "$SCAFFOLD_ROOT" validate
 grep -q "${DATABASE_NAME}_preview_feature_generated_example" "$TMP_DIR/render.out"
 grep -q "\"alias\": \"${DATABASE_NAME}\"" "$TMP_DIR/render.out"
 grep -q '"scheduleCron": ""' "$TMP_DIR/render.out"
+"$SCAFFOLD_ROOT/tools/md_blueprints" render \
+  --root "$SCAFFOLD_ROOT" \
+  --target preview \
+  --branch "$BRANCH_NAME" \
+  --blueprints "123" > "$TMP_DIR/numeric-render.out"
+grep -q "_123_preview_feature_generated_example" "$TMP_DIR/numeric-render.out"
+grep -q '"alias": "_123"' "$TMP_DIR/numeric-render.out"
 
 echo "==> Building generated blueprint Dive"
 make -C "$SCAFFOLD_ROOT" preview-smoke "$EXAMPLE_NAME"
@@ -54,9 +75,20 @@ echo "==> Building generated external-share Dive"
   --url "md:_share/example/00000000-0000-0000-0000-000000000000"
 make -C "$SCAFFOLD_ROOT" preview-smoke "external-share-example"
 
+echo "==> Building generated input-backed Dive"
+make -C "$SCAFFOLD_ROOT" preview-smoke "1-dashboard"
+
+echo "==> Building generated numeric-leading project Dive"
+make -C "$SCAFFOLD_ROOT" preview-smoke "123"
+
 echo "==> Destroying generated blueprint example"
 rm -rf "$SCAFFOLD_ROOT/projects/$EXAMPLE_NAME"
 rm -rf "$SCAFFOLD_ROOT/dives/external-share-example"
+rm -rf "$SCAFFOLD_ROOT/flights/true"
+rm -rf "$SCAFFOLD_ROOT/dives/1-dashboard"
+rm -rf "$SCAFFOLD_ROOT/guides/on"
+rm -rf "$SCAFFOLD_ROOT/roles/null"
+rm -rf "$SCAFFOLD_ROOT/projects/123"
 test ! -e "$SCAFFOLD_ROOT/projects/$EXAMPLE_NAME"
 test ! -e "$SCAFFOLD_ROOT/dives/external-share-example"
 make -C "$SCAFFOLD_ROOT" validate

--- a/src/md_blueprints/scaffold.py
+++ b/src/md_blueprints/scaffold.py
@@ -16,8 +16,21 @@ def _title(name: str) -> str:
     return " ".join(part.capitalize() for part in name.split("-"))
 
 
+def _yaml_string(value: str) -> str:
+    return json.dumps(value)
+
+
+def _default_alias(name: str) -> str:
+    alias = name.replace("-", "_")
+    return alias if not alias[0].isdigit() else f"_{alias}"
+
+
 def _render(text: str, *, name: str, alias: str, required_database: str | None = None) -> str:
-    rendered = text.replace("__BLUEPRINT_NAME__", name).replace("__DATABASE_NAME__", alias)
+    rendered = (
+        text.replace("__BLUEPRINT_NAME__", name)
+        .replace("__BLUEPRINT_TITLE__", _title(name))
+        .replace("__DATABASE_NAME__", alias)
+    )
     if required_database is not None:
         rendered = rendered.replace("__REQUIRED_DATABASE__", required_database)
     return rendered
@@ -55,8 +68,24 @@ def run_new(
     if destination.exists():
         raise ValidationError(f"Blueprint already exists: {destination.relative_to(root)}")
 
-    resource_alias = alias or name.replace("-", "_")
-    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", resource_alias):
+    if kind != "dive" and (input_ref is not None or share_url is not None):
+        raise ValidationError("--input and --url are only valid for new dive")
+    if kind in {"guide", "role"} and alias is not None:
+        raise ValidationError("--alias is only valid for new flight, dive, or project")
+    if alias is not None and not alias:
+        raise ValidationError("--alias must not be empty")
+    if share_url is not None:
+        share_url = share_url.strip()
+
+    from .project import Project
+
+    if name in Project(root).all_blueprint_names():
+        raise ValidationError(f"Blueprint name already exists: {name}")
+
+    resource_alias = alias or _default_alias(name)
+    if kind in {"flight", "dive", "project"} and not re.fullmatch(
+        r"[A-Za-z_][A-Za-z0-9_]*", resource_alias
+    ):
         raise ValidationError("Alias must be a SQL identifier using letters, numbers, and underscores")
 
     if kind == "dive":
@@ -89,15 +118,20 @@ def run_new(
     elif kind == "role":
         _write(destination / "blueprint.yml", _role_manifest(name))
     else:
-        _write(destination / "blueprint.yml", _project_manifest(name, resource_alias))
+        _write(
+            destination / "blueprint.yml",
+            _render(_starter_source("blueprint.yml"), name=name, alias=resource_alias),
+        )
         _write(destination / "src/flight.py", _render(_starter_source("flight.py"), name=name, alias=resource_alias))
         _write(destination / "src/requirements.txt", _starter_source("requirements.txt"))
         _write(destination / "src/dive.tsx", _render(_starter_source("dive.tsx"), name=name, alias=resource_alias))
 
-    _write(
-        destination / "README.md",
-        f"# {_title(name)}\n\nGenerated `{kind}` blueprint. Run `make validate` before opening a PR.\n",
+    readme = (
+        _render(_starter_source("README.md"), name=name, alias=resource_alias)
+        if kind == "project"
+        else f"# {_title(name)}\n\nGenerated `{kind}` blueprint. Run `make validate` before opening a PR.\n"
     )
+    _write(destination / "README.md", readme)
     print(f"Created {destination.relative_to(root)}")
     return destination
 
@@ -105,9 +139,9 @@ def run_new(
 def _share_and_flight(name: str, alias: str) -> str:
     return f"""variables:
   database:
-    default: {alias}
+    default: {_yaml_string(alias)}
   share:
-    default: {alias}
+    default: {_yaml_string(alias)}
   schema:
     default: main
 
@@ -129,7 +163,7 @@ resources:
           dropDatabase: true
   flights:
     loader:
-      name: {name}
+      name: {_yaml_string(name)}
       source: src/flight.py
       requirements: src/requirements.txt
       scheduleCron: ""
@@ -143,14 +177,14 @@ resources:
         share_visibility: ${{resources.shares.data.visibility}}
       targets:
         preview:
-          name: {name}:${{target.branch}} (Preview)
+          name: {_yaml_string(f"{name}:${{target.branch}} (Preview)")}
 """
 
 
 def _flight_manifest(name: str, alias: str) -> str:
     return f"""schemaVersion: 1
-name: {name}
-title: {_title(name)}
+name: {_yaml_string(name)}
+title: {_yaml_string(_title(name))}
 description: Flight package that publishes a share for downstream blueprints.
 
 outputs:
@@ -165,8 +199,8 @@ def _dive_manifest(name: str, alias: str, *, input_ref: str | None, share_url: s
         producer, output = _parse_input_ref(input_ref)
         contract = f"""inputs:
   data:
-    blueprint: {producer}
-    output: {json.dumps(output)}
+    blueprint: {_yaml_string(producer)}
+    output: {_yaml_string(output)}
 
 """
         required = "input: data"
@@ -177,21 +211,21 @@ def _dive_manifest(name: str, alias: str, *, input_ref: str | None, share_url: s
         contract = ""
         required = f"url: {json.dumps(share_url)}"
     return f"""schemaVersion: 1
-name: {name}
-title: {_title(name)}
+name: {_yaml_string(name)}
+title: {_yaml_string(_title(name))}
 description: Dive package backed by a declared data input.
 
 {contract}resources:
   dives:
     dashboard:
-      title: {_title(name)}
+      title: {_yaml_string(_title(name))}
       source: src/dive.tsx
       requiredResources:
         - {required}
-          alias: {alias}
+          alias: {_yaml_string(alias)}
       targets:
         preview:
-          title: {_title(name)}:${{target.branch}} (Preview)
+          title: {_yaml_string(f"{_title(name)}:${{target.branch}} (Preview)")}
 """
 
 
@@ -232,15 +266,15 @@ def _required_database(
 
 def _guide_manifest(name: str) -> str:
     return f"""schemaVersion: 1
-name: {name}
-title: {_title(name)}
+name: {_yaml_string(name)}
+title: {_yaml_string(_title(name))}
 description: Version-controlled Guide for agents and collaborators.
 
 resources:
   guides:
     guide:
-      title: {_title(name)}
-      topic: {name}
+      title: {_yaml_string(_title(name))}
+      topic: {_yaml_string(name)}
       source: guide.md
       deploy: false
 """
@@ -248,32 +282,16 @@ resources:
 
 def _role_manifest(name: str) -> str:
     return f"""schemaVersion: 1
-name: {name}
-title: {_title(name)}
+name: {_yaml_string(name)}
+title: {_yaml_string(_title(name))}
 description: Version-controlled MotherDuck role and membership assignments.
 
 resources:
   roles:
     role:
-      name: {name}
+      name: {_yaml_string(name)}
       includedRoles: []
       members: []
       mode: additive
       deploy: true
-"""
-
-
-def _project_manifest(name: str, alias: str) -> str:
-    base = _flight_manifest(name, alias)
-    return base + f"""
-  dives:
-    dashboard:
-      title: {_title(name)}
-      source: src/dive.tsx
-      requiredResources:
-        - share: data
-          alias: {alias}
-      targets:
-        preview:
-          title: {_title(name)}:${{target.branch}} (Preview)
 """

--- a/src/md_blueprints/template_repo/templates/blueprint/blueprint.yml
+++ b/src/md_blueprints/template_repo/templates/blueprint/blueprint.yml
@@ -1,6 +1,6 @@
 schemaVersion: 1
-name: __BLUEPRINT_NAME__
-title: __BLUEPRINT_NAME__
+name: "__BLUEPRINT_NAME__"
+title: "__BLUEPRINT_TITLE__"
 description: Starter project that publishes a small daily metrics dataset and reads it from a Dive.
 
 outputs:
@@ -10,10 +10,10 @@ outputs:
 variables:
   database:
     description: MotherDuck database that stores this project's data.
-    default: __DATABASE_NAME__
+    default: "__DATABASE_NAME__"
   share:
     description: MotherDuck share published by the loader Flight.
-    default: __DATABASE_NAME__
+    default: "__DATABASE_NAME__"
   schema:
     description: Schema that contains the starter tables and views.
     default: main
@@ -37,7 +37,7 @@ resources:
 
   flights:
     loader:
-      name: __BLUEPRINT_NAME__
+      name: "__BLUEPRINT_NAME__"
       source: src/flight.py
       requirements: src/requirements.txt
       scheduleCron: ""
@@ -51,17 +51,17 @@ resources:
         share_visibility: ${resources.shares.data.visibility}
       targets:
         preview:
-          name: __BLUEPRINT_NAME__:${target.branch} (Preview)
+          name: "__BLUEPRINT_NAME__:${target.branch} (Preview)"
 
   dives:
     dashboard:
-      title: __BLUEPRINT_NAME__
+      title: "__BLUEPRINT_TITLE__"
       source: src/dive.tsx
       status: ready
       requiredResources:
         - share: data
-          alias: __DATABASE_NAME__
+          alias: "__DATABASE_NAME__"
       targets:
         preview:
-          title: __BLUEPRINT_NAME__:${target.branch} (Preview)
+          title: "__BLUEPRINT_TITLE__:${target.branch} (Preview)"
           status: draft

--- a/templates/blueprint/blueprint.yml
+++ b/templates/blueprint/blueprint.yml
@@ -1,6 +1,6 @@
 schemaVersion: 1
-name: __BLUEPRINT_NAME__
-title: __BLUEPRINT_NAME__
+name: "__BLUEPRINT_NAME__"
+title: "__BLUEPRINT_TITLE__"
 description: Starter project that publishes a small daily metrics dataset and reads it from a Dive.
 
 outputs:
@@ -10,10 +10,10 @@ outputs:
 variables:
   database:
     description: MotherDuck database that stores this project's data.
-    default: __DATABASE_NAME__
+    default: "__DATABASE_NAME__"
   share:
     description: MotherDuck share published by the loader Flight.
-    default: __DATABASE_NAME__
+    default: "__DATABASE_NAME__"
   schema:
     description: Schema that contains the starter tables and views.
     default: main
@@ -37,7 +37,7 @@ resources:
 
   flights:
     loader:
-      name: __BLUEPRINT_NAME__
+      name: "__BLUEPRINT_NAME__"
       source: src/flight.py
       requirements: src/requirements.txt
       scheduleCron: ""
@@ -51,17 +51,17 @@ resources:
         share_visibility: ${resources.shares.data.visibility}
       targets:
         preview:
-          name: __BLUEPRINT_NAME__:${target.branch} (Preview)
+          name: "__BLUEPRINT_NAME__:${target.branch} (Preview)"
 
   dives:
     dashboard:
-      title: __BLUEPRINT_NAME__
+      title: "__BLUEPRINT_TITLE__"
       source: src/dive.tsx
       status: ready
       requiredResources:
         - share: data
-          alias: __DATABASE_NAME__
+          alias: "__DATABASE_NAME__"
       targets:
         preview:
-          title: __BLUEPRINT_NAME__:${target.branch} (Preview)
+          title: "__BLUEPRINT_TITLE__:${target.branch} (Preview)"
           status: draft

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -64,6 +64,105 @@ def test_all_typed_scaffolds_generate_a_valid_repository(tmp_path: Path) -> None
     assert (tmp_path / "projects/revenue/src/dive.tsx").is_file()
 
 
+@pytest.mark.parametrize("kind", ["flight", "dive", "guide", "role", "project"])
+@pytest.mark.parametrize(
+    "name",
+    ["1alpha", "123", "true", "false", "null", "yes", "no", "on", "off", "2026-07-30"],
+)
+def test_typed_scaffolds_support_all_schema_valid_slug_shapes(
+    tmp_path: Path, kind: str, name: str
+) -> None:
+    write_root(tmp_path)
+    options = {"share_url": "md:_share/example/id"} if kind == "dive" else {}
+
+    destination = run_new(tmp_path, kind, name, **options)
+
+    assert Project(tmp_path).validate()
+    loaded = load_yaml(destination / "blueprint.yml")
+    assert isinstance(loaded, dict)
+    assert loaded["name"] == name
+    assert isinstance(loaded["title"], str)
+
+
+@pytest.mark.parametrize("alias", ["true", "false", "null", "yes", "no", "on", "off"])
+def test_new_dive_quotes_yaml_reserved_aliases(tmp_path: Path, alias: str) -> None:
+    write_root(tmp_path)
+
+    destination = run_new(
+        tmp_path,
+        "dive",
+        "external-dashboard",
+        share_url="md:_share/example/id",
+        alias=alias,
+    )
+
+    assert Project(tmp_path).validate()
+    loaded = load_yaml(destination / "blueprint.yml")
+    assert isinstance(loaded, dict)
+    required = loaded["resources"]["dives"]["dashboard"]["requiredResources"]
+    assert required[0]["alias"] == alias
+
+
+def test_numeric_leading_slug_gets_a_safe_default_alias(tmp_path: Path) -> None:
+    write_root(tmp_path)
+
+    project = run_new(tmp_path, "project", "123-metrics")
+    dive = run_new(
+        tmp_path,
+        "dive",
+        "456-dashboard",
+        share_url="md:_share/example/id",
+    )
+
+    assert Project(tmp_path).validate()
+    assert 'default: "_123_metrics"' in (project / "blueprint.yml").read_text(encoding="utf-8")
+    assert 'alias: "_456_dashboard"' in (dive / "blueprint.yml").read_text(encoding="utf-8")
+
+
+def test_new_rejects_duplicate_name_across_typed_roots_before_writing(tmp_path: Path) -> None:
+    write_root(tmp_path)
+    run_new(tmp_path, "flight", "shared-name")
+
+    with pytest.raises(ValidationError, match="Blueprint name already exists"):
+        run_new(tmp_path, "guide", "shared-name")
+
+    assert not (tmp_path / "guides/shared-name").exists()
+
+
+@pytest.mark.parametrize(
+    ("kind", "options", "message"),
+    [
+        ("flight", {"input_ref": "producer.data"}, "--input and --url"),
+        ("guide", {"share_url": "md:_share/example/id"}, "--input and --url"),
+        ("role", {"alias": "custom"}, "--alias is only valid"),
+    ],
+)
+def test_new_rejects_options_that_do_not_apply_to_the_kind(
+    tmp_path: Path, kind: str, options: dict[str, str], message: str
+) -> None:
+    write_root(tmp_path)
+
+    with pytest.raises(ValidationError, match=message):
+        run_new(tmp_path, kind, "invalid-options", **options)
+
+    assert not (tmp_path / f"{kind}s/invalid-options").exists()
+
+
+def test_new_project_uses_the_complete_starter_template(tmp_path: Path) -> None:
+    write_root(tmp_path)
+
+    destination = run_new(tmp_path, "project", "daily-metrics")
+
+    manifest = (destination / "blueprint.yml").read_text(encoding="utf-8")
+    readme = (destination / "README.md").read_text(encoding="utf-8")
+    assert "status: ready" in manifest
+    assert "status: draft" in manifest
+    assert "Starter project that publishes" in manifest
+    assert "## Replace the Starter Logic" in readme
+    assert "__BLUEPRINT_" not in manifest
+    assert "__BLUEPRINT_" not in readme
+
+
 def test_new_dive_requires_one_data_source(tmp_path: Path) -> None:
     write_root(tmp_path)
 
@@ -77,6 +176,21 @@ def test_new_dive_requires_one_data_source(tmp_path: Path) -> None:
             input_ref="producer.data",
             share_url="md:_share/example/id",
         )
+
+
+def test_new_dive_rejects_an_explicitly_empty_alias(tmp_path: Path) -> None:
+    write_root(tmp_path)
+
+    with pytest.raises(ValidationError, match="--alias must not be empty"):
+        run_new(
+            tmp_path,
+            "dive",
+            "empty-alias",
+            share_url="md:_share/example/id",
+            alias="",
+        )
+
+    assert not (tmp_path / "dives/empty-alias").exists()
 
 
 def test_new_dive_accepts_non_slug_output_keys_and_uses_schema_neutral_source(tmp_path: Path) -> None:
@@ -122,10 +236,14 @@ def test_new_external_dive_preserves_share_url_for_local_preview(tmp_path: Path)
         tmp_path,
         "dive",
         "external-dashboard",
-        share_url="md:_share/example/id",
+        share_url="  md:_share/example/id  ",
         alias="external_data",
     )
     source = (destination / "src/dive.tsx").read_text(encoding="utf-8")
+    loaded = load_yaml(destination / "blueprint.yml")
 
+    assert isinstance(loaded, dict)
+    required = loaded["resources"]["dives"]["dashboard"]["requiredResources"]
+    assert required[0]["url"] == "md:_share/example/id"
     assert '"path": "md:_share/example/id"' in source
     assert '"alias": "external_data"' in source


### PR DESCRIPTION
Blueprint scaffolding accepted schema-valid names that could render invalid YAML or SQL aliases, and project generation had drifted from the canonical starter. This fixes those generation paths and broadens executable coverage so generated repositories remain valid across supported resource types.

### Codex description

- quote dynamic YAML values, normalize numeric-leading aliases and external-share URLs, reject empty or irrelevant options, and prevent cross-root duplicate names
- generate complete projects from the canonical starter manifest and README
- exercise reserved names, numeric-leading projects, typed resources, installed-wheel scaffolding, preview rendering, and Dive builds in tests and smoke checks