### PR TITLE
feat: simplify blueprints onboarding and deployment

### DIFF
--- a/.dive-preview/package-lock.json
+++ b/.dive-preview/package-lock.json
@@ -1253,9 +1253,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,10 +13,12 @@
 - [ ] Dives list required resources in `blueprint.yml`.
 - [ ] Dive statuses are intentional: previews are `draft`, and `endorsed` production changes have an organization-admin reviewer.
 - [ ] Preview shares/databases that can be cleaned up include `${target.branch_slug}`.
+- [ ] If `staging` is configured, staging shares have names distinct from production while database names may intentionally match.
+- [ ] Deployment tokens are GitHub Environment secrets named `MOTHERDUCK_TOKEN`, not repository-level secrets or tracked values.
 - [ ] Blueprints validate with `make validate`.
 - [ ] Dives build with `make preview-smoke <blueprint-name>` when changed.
 - [ ] Package/action/schema docs are updated when tooling behavior changed.
 - [ ] Release version checks pass when package metadata changed.
 - [ ] Docs are updated when layout, commands, target behavior, or resource semantics changed.
 - [ ] `CHANGELOG.md` is updated.
-- [ ] Production deploy has an owner/reviewer.
+- [ ] Production deploy has an owner/reviewer; staged repositories promote production only from a published release.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -169,7 +169,10 @@ jobs:
         run: npm audit --audit-level=high
 
       - name: Lint GitHub Actions workflows
-        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+        run: >-
+          go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+          .github/workflows/*.yaml
+          src/md_blueprints/template_repo/.github/workflows/*.yaml
 
       - name: Lint shell scripts
         run: shellcheck scripts/*.sh

--- a/.github/workflows/cleanup_preview_blueprints.yaml
+++ b/.github/workflows/cleanup_preview_blueprints.yaml
@@ -1,3 +1,4 @@
+# md-blueprints-environment-model: v1
 name: Cleanup Preview Blueprints
 
 permissions:
@@ -14,10 +15,66 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  resolve-environment:
+    name: Resolve Preview Environment
+    if: >-
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'delete' && github.event.ref_type == 'branch')
+    runs-on: ubuntu-latest
+    outputs:
+      environment: ${{ steps.preview-target.outputs.environment }}
+      identity: ${{ steps.preview-target.outputs.identity }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
+
+      - name: Validate base deployment configuration
+        uses: ./
+        with:
+          command: validate
+
+      - name: Resolve preview target
+        id: preview-target
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import os
+          from pathlib import Path
+
+          import yaml
+
+          manifest = yaml.safe_load(Path("motherduck.yml").read_text(encoding="utf-8"))
+          preview = manifest.get("targets", {}).get("preview", {})
+          environment = str(preview.get("environment", "")).strip()
+          deployment = preview.get("deployment", {})
+          identity = str(deployment.get("identity", "")).strip() if isinstance(deployment, dict) else ""
+          token_env_var = (
+              str(deployment.get("tokenEnvVar", "MOTHERDUCK_TOKEN")).strip()
+              if isinstance(deployment, dict)
+              else ""
+          )
+          if not environment or not identity:
+              raise SystemExit(
+                  "Target 'preview' must declare environment and deployment.identity before preview cleanup"
+              )
+          if token_env_var != "MOTHERDUCK_TOKEN":
+              raise SystemExit(
+                  "Target 'preview' must use deployment.tokenEnvVar: MOTHERDUCK_TOKEN with the generated "
+                  "GitHub Environment workflow"
+              )
+          output = Path(os.environ["GITHUB_OUTPUT"])
+          with output.open("a", encoding="utf-8") as handle:
+              handle.write(f"environment={environment}\n")
+              handle.write(f"identity={identity}\n")
+          PY
+
   cleanup:
     name: Delete Preview Blueprints for Branch
-    if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'delete' && github.event.ref_type == 'branch')
+    needs: resolve-environment
     runs-on: ubuntu-latest
+    environment: ${{ needs.resolve-environment.outputs.environment }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -33,56 +90,53 @@ jobs:
           set -euo pipefail
           branch_name="${PR_BRANCH:-$DELETED_BRANCH}"
           if [ -z "$branch_name" ]; then
-            echo "No branch name available for cleanup"
-            echo "available=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=true" >> "$GITHUB_OUTPUT"
-            echo "branch=${branch_name}" >> "$GITHUB_OUTPUT"
+            echo "No branch name available for cleanup" >&2
+            exit 1
           fi
+          echo "branch=${branch_name}" >> "$GITHUB_OUTPUT"
 
-      - name: Check cleanup token
-        id: cleanup-token
-        if: steps.cleanup-branch.outputs.available == 'true'
+      - name: Require preview environment token
         shell: bash
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          TARGET_ENVIRONMENT: ${{ needs.resolve-environment.outputs.environment }}
+          TARGET_IDENTITY: ${{ needs.resolve-environment.outputs.identity }}
         run: |
           set -euo pipefail
           if [ -z "$MOTHERDUCK_TOKEN" ]; then
-            echo "Preview cleanup skipped because MOTHERDUCK_TOKEN is not configured for this repository."
-            echo "available=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "Target preview expects GitHub Environment '$TARGET_ENVIRONMENT' to contain a MOTHERDUCK_TOKEN secret for $TARGET_IDENTITY." >&2
+            exit 1
           fi
 
       - name: Cleanup preview blueprints from the branch manifest
         id: cleanup-branch-manifest
-        if: steps.cleanup-token.outputs.available == 'true'
         continue-on-error: ${{ github.event_name == 'pull_request' }}
         uses: ./
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         with:
           command: cleanup
-          args: --target preview --branch "${{ steps.cleanup-branch.outputs.branch }}"
+          target: preview
+          branch: ${{ steps.cleanup-branch.outputs.branch }}
 
       - name: Check out the pull request base manifest
-        if: github.event_name == 'pull_request' && steps.cleanup-token.outputs.available == 'true'
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Cleanup preview blueprints from the base manifest
-        if: github.event_name == 'pull_request' && steps.cleanup-token.outputs.available == 'true'
+        if: ${{ github.event_name == 'pull_request' }}
         uses: ./
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         with:
           command: cleanup
-          args: --target preview --branch "${{ steps.cleanup-branch.outputs.branch }}"
+          target: preview
+          branch: ${{ steps.cleanup-branch.outputs.branch }}
 
       - name: Report branch-manifest cleanup failure
-        if: always() && steps.cleanup-branch-manifest.outcome == 'failure'
+        if: ${{ always() && steps.cleanup-branch-manifest.outcome == 'failure' }}
         shell: bash
         run: |
           echo "Cleanup using the pull request branch manifest failed; the base manifest cleanup was still attempted." >&2

--- a/.github/workflows/deploy_blueprints.yaml
+++ b/.github/workflows/deploy_blueprints.yaml
@@ -167,11 +167,11 @@ jobs:
               if isinstance(deployment, dict)
               else ""
           )
-          if not environment or not identity:
+          if deployment_enabled and (not environment or not identity):
               raise SystemExit(
                   f"Target {target!r} must declare environment and deployment.identity before live CI deployment"
               )
-          if token_env_var != "MOTHERDUCK_TOKEN":
+          if deployment_enabled and token_env_var != "MOTHERDUCK_TOKEN":
               raise SystemExit(
                   f"Target {target!r} must use deployment.tokenEnvVar: MOTHERDUCK_TOKEN with the generated "
                   "GitHub Environment workflow"

--- a/.github/workflows/deploy_blueprints.yaml
+++ b/.github/workflows/deploy_blueprints.yaml
@@ -1,12 +1,9 @@
+# md-blueprints-environment-model: v1
 name: Deploy Blueprints
 
 permissions:
   contents: read
   pull-requests: write
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
   workflow_dispatch:
@@ -18,6 +15,7 @@ on:
         type: choice
         options:
           - preview
+          - staging
           - prod
       branch:
         description: Preview branch name for manual preview deploys.
@@ -65,22 +63,132 @@ on:
       - "action.yml"
       - "pyproject.toml"
       - ".github/workflows/deploy_blueprints.yaml"
+  release:
+    types:
+      - published
 
 jobs:
   compute_changes:
-    name: Identify Changed Blueprints
+    name: Validate and Identify Deployment
     runs-on: ubuntu-latest
     outputs:
       changed_blueprints: ${{ steps.changed.outputs.changed_blueprints }}
       changed_csv: ${{ steps.changed.outputs.changed_csv }}
+      target: ${{ steps.topology.outputs.target }}
+      target_environment: ${{ steps.topology.outputs.environment }}
+      target_identity: ${{ steps.topology.outputs.identity }}
+      staging_enabled: ${{ steps.topology.outputs.staging_enabled }}
+      deployment_enabled: ${{ steps.topology.outputs.deployment_enabled }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
+
+      - name: Validate configured targets
+        uses: ./
+        with:
+          command: validate
+
+      - name: Resolve deployment topology
+        id: topology
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TARGET: ${{ inputs.target }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import os
+          import subprocess
+          from pathlib import Path
+
+          import yaml
+
+          manifest = yaml.safe_load(Path("motherduck.yml").read_text(encoding="utf-8"))
+          targets = manifest.get("targets", {})
+          staging_enabled = "staging" in targets
+          event_name = os.environ["EVENT_NAME"]
+          deployment_enabled = True
+
+          if event_name == "pull_request":
+              target = "preview"
+          elif event_name == "push":
+              target = "staging" if staging_enabled else "prod"
+          elif event_name == "release":
+              target = "prod"
+              deployment_enabled = staging_enabled and os.environ.get("RELEASE_PRERELEASE", "false") != "true"
+          elif event_name == "workflow_dispatch":
+              target = os.environ.get("INPUT_TARGET", "prod") or "prod"
+          else:
+              raise SystemExit(f"Unsupported deployment event: {event_name}")
+
+          if target not in targets:
+              raise SystemExit(
+                  f"Target {target!r} is not declared in motherduck.yml. "
+                  "Add targets.staging before dispatching a staging deployment."
+              )
+
+          config = targets[target]
+          if event_name == "pull_request":
+              base_ref = os.environ.get("BASE_REF", "")
+              base_text = subprocess.check_output(
+                  ["git", "show", f"origin/{base_ref}:motherduck.yml"],
+                  text=True,
+              )
+              base_manifest = yaml.safe_load(base_text)
+              base_config = base_manifest.get("targets", {}).get("preview", {})
+              branch_deployment = config.get("deployment", {})
+              base_deployment = base_config.get("deployment", {})
+              branch_identity = (
+                  str(branch_deployment.get("identity", "")).strip()
+                  if isinstance(branch_deployment, dict)
+                  else ""
+              )
+              base_identity = (
+                  str(base_deployment.get("identity", "")).strip()
+                  if isinstance(base_deployment, dict)
+                  else ""
+              )
+              if (
+                  str(config.get("environment", "")).strip()
+                  != str(base_config.get("environment", "")).strip()
+                  or branch_identity != base_identity
+              ):
+                  deployment_enabled = False
+              config = base_config
+          environment = str(config.get("environment", "")).strip()
+          deployment = config.get("deployment", {})
+          identity = str(deployment.get("identity", "")).strip() if isinstance(deployment, dict) else ""
+          token_env_var = (
+              str(deployment.get("tokenEnvVar", "MOTHERDUCK_TOKEN")).strip()
+              if isinstance(deployment, dict)
+              else ""
+          )
+          if not environment or not identity:
+              raise SystemExit(
+                  f"Target {target!r} must declare environment and deployment.identity before live CI deployment"
+              )
+          if token_env_var != "MOTHERDUCK_TOKEN":
+              raise SystemExit(
+                  f"Target {target!r} must use deployment.tokenEnvVar: MOTHERDUCK_TOKEN with the generated "
+                  "GitHub Environment workflow"
+              )
+
+          output = Path(os.environ["GITHUB_OUTPUT"])
+          with output.open("a", encoding="utf-8") as handle:
+              handle.write(f"target={target}\n")
+              handle.write(f"environment={environment}\n")
+              handle.write(f"identity={identity}\n")
+              handle.write(f"staging_enabled={str(staging_enabled).lower()}\n")
+              handle.write(f"deployment_enabled={str(deployment_enabled).lower()}\n")
+          PY
 
       - name: Use manually selected blueprints
         id: manual-changed
-        if: ${{ inputs.blueprints != '' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.blueprints != '' }}
         shell: bash
         env:
           INPUT_BLUEPRINTS: ${{ inputs.blueprints }}
@@ -91,7 +199,7 @@ jobs:
 
       - name: Compute changed blueprints for pull request
         id: changed-pr
-        if: ${{ inputs.blueprints == '' && github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' }}
         uses: ./
         with:
           command: changed
@@ -99,7 +207,7 @@ jobs:
 
       - name: Resolve push comparison range
         id: push-range
-        if: ${{ inputs.blueprints == '' && github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' }}
         shell: bash
         env:
           PUSH_BEFORE: ${{ github.event.before }}
@@ -113,15 +221,15 @@ jobs:
 
       - name: Compute changed blueprints for push
         id: changed-push
-        if: ${{ inputs.blueprints == '' && github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' }}
         uses: ./
         with:
           command: changed
           args: ${{ steps.push-range.outputs.args }}
 
-      - name: Select all blueprints for manual dispatch
+      - name: Select all blueprints
         id: changed-all
-        if: ${{ inputs.blueprints == '' && github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.blueprints == '') }}
         uses: ./
         with:
           command: changed
@@ -143,25 +251,19 @@ jobs:
           echo "changed_blueprints=${changed}" >> "$GITHUB_OUTPUT"
           echo "changed_csv=${csv}" >> "$GITHUB_OUTPUT"
 
-  validate:
-    name: Validate Blueprints
-    needs: compute_changes
-    if: needs.compute_changes.outputs.changed_blueprints != '[]'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - uses: ./
-        with:
-          command: validate
-
   deploy-preview:
     name: Deploy Preview Blueprints
-    needs:
-      - compute_changes
-      - validate
-    if: needs.compute_changes.outputs.changed_blueprints != '[]' && (github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.target == 'preview'))
+    needs: compute_changes
+    if: >-
+      needs.compute_changes.outputs.changed_blueprints != '[]' &&
+      needs.compute_changes.outputs.target == 'preview' &&
+      needs.compute_changes.outputs.deployment_enabled == 'true' &&
+      (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
+    environment: ${{ needs.compute_changes.outputs.target_environment }}
+    concurrency:
+      group: preview-${{ github.event.pull_request.number || inputs.branch }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -178,82 +280,58 @@ jobs:
           fi
           echo "branch=${PREVIEW_BRANCH}" >> "$GITHUB_OUTPUT"
 
-      - name: Check preview token
-        id: preview-token
+      - name: Require preview environment token
         shell: bash
         env:
-          EVENT_NAME: ${{ github.event_name }}
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          TARGET_ENVIRONMENT: ${{ needs.compute_changes.outputs.target_environment }}
+          TARGET_IDENTITY: ${{ needs.compute_changes.outputs.target_identity }}
         run: |
           set -euo pipefail
-          if [ -n "$MOTHERDUCK_TOKEN" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          elif [ "$EVENT_NAME" = "pull_request" ]; then
-            echo "available=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "MOTHERDUCK_TOKEN is required for preview deploys" >&2
+          if [ -z "$MOTHERDUCK_TOKEN" ]; then
+            echo "Target preview expects GitHub Environment '$TARGET_ENVIRONMENT' to contain a MOTHERDUCK_TOKEN secret for $TARGET_IDENTITY." >&2
             exit 1
           fi
 
       - name: Plan preview blueprints
         id: plan-preview
-        if: steps.preview-token.outputs.available == 'true'
         uses: ./
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         with:
           command: plan
-          args: --target preview --branch "${{ steps.preview-branch.outputs.branch }}" --blueprints "${{ needs.compute_changes.outputs.changed_csv }}"
+          target: preview
+          branch: ${{ steps.preview-branch.outputs.branch }}
+          blueprints: ${{ needs.compute_changes.outputs.changed_csv }}
 
       - name: Deploy preview blueprints
         id: deploy-preview
-        if: steps.preview-token.outputs.available == 'true'
         uses: ./
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         with:
           command: deploy
-          args: --target preview --branch "${{ steps.preview-branch.outputs.branch }}" --blueprints "${{ needs.compute_changes.outputs.changed_csv }}"
+          target: preview
+          branch: ${{ steps.preview-branch.outputs.branch }}
+          blueprints: ${{ needs.compute_changes.outputs.changed_csv }}
 
-      - name: Build preview comment body
-        id: preview-comment
-        shell: bash
-        env:
-          TOKEN_AVAILABLE: ${{ steps.preview-token.outputs.available }}
-          PLAN_OUTPUT: ${{ steps.plan-preview.outputs.stdout }}
-          DEPLOY_OUTPUT: ${{ steps.deploy-preview.outputs.stdout }}
-        run: |
-          set -euo pipefail
-          if [ "$TOKEN_AVAILABLE" = "true" ]; then
-            output="$(printf "%s\n\n%s" "$PLAN_OUTPUT" "$DEPLOY_OUTPUT")"
-          else
-            output="Preview deploy skipped because MOTHERDUCK_TOKEN is not configured for this repository."
-          fi
-          {
-            echo "comment_body<<EOF"
-            printf "%s\n" "$output"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Comment on PR
-        if: github.event_name == 'pull_request' && steps.preview-comment.outputs.comment_body != ''
+      - name: Comment on pull request
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          COMMENT_BODY: ${{ steps.preview-comment.outputs.comment_body }}
+          PLAN_OUTPUT: ${{ steps.plan-preview.outputs.stdout }}
+          DEPLOY_OUTPUT: ${{ steps.deploy-preview.outputs.stdout }}
         with:
           script: |
             const marker = '<!-- preview-blueprints-comment -->';
-            const body = `${marker}
-            ### Preview Blueprints
-
-            ${process.env.COMMENT_BODY ?? ''}`.replace(/^ +/gm, '');
-
+            const output = `${process.env.PLAN_OUTPUT ?? ''}\n\n${process.env.DEPLOY_OUTPUT ?? ''}`;
+            const body = `${marker}\n### Preview Blueprints\n\n${output}`;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
             });
-            const existing = comments.find(c => c.body.includes(marker));
+            const existing = comments.find(comment => comment.body.includes(marker));
             if (existing) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,
@@ -270,58 +348,138 @@ jobs:
               });
             }
 
-  deploy-prod:
-    name: Deploy Production Blueprints
-    needs:
-      - compute_changes
-      - validate
-    if: needs.compute_changes.outputs.changed_blueprints != '[]' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.target == 'prod'))
+  deploy-stable:
+    name: Deploy ${{ needs.compute_changes.outputs.target }} Blueprints
+    needs: compute_changes
+    if: >-
+      needs.compute_changes.outputs.changed_blueprints != '[]' &&
+      needs.compute_changes.outputs.target != 'preview' &&
+      github.event_name != 'release'
     runs-on: ubuntu-latest
-    environment: motherduck-production
+    environment: ${{ needs.compute_changes.outputs.target_environment }}
+    concurrency:
+      group: stable-${{ needs.compute_changes.outputs.target }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Check production token
-        id: prod-token
+      - name: Require target environment token
         shell: bash
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          TARGET: ${{ needs.compute_changes.outputs.target }}
+          TARGET_ENVIRONMENT: ${{ needs.compute_changes.outputs.target_environment }}
+          TARGET_IDENTITY: ${{ needs.compute_changes.outputs.target_identity }}
         run: |
           set -euo pipefail
-          if [ -n "$MOTHERDUCK_TOKEN" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "Production deploy skipped because MOTHERDUCK_TOKEN is not configured for this repository."
+          if [ -z "$MOTHERDUCK_TOKEN" ]; then
+            echo "Target $TARGET expects GitHub Environment '$TARGET_ENVIRONMENT' to contain a MOTHERDUCK_TOKEN secret for $TARGET_IDENTITY." >&2
+            exit 1
           fi
 
-      - name: Plan production blueprints
-        id: plan-prod
-        if: steps.prod-token.outputs.available == 'true'
+      - name: Plan target blueprints
+        id: plan-stable
         uses: ./
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         with:
           command: plan
-          args: --target prod --blueprints "${{ needs.compute_changes.outputs.changed_csv }}"
+          target: ${{ needs.compute_changes.outputs.target }}
+          blueprints: ${{ needs.compute_changes.outputs.changed_csv }}
 
-      - name: Summarize production plan
-        if: steps.prod-token.outputs.available == 'true'
+      - name: Summarize deployment plan
         shell: bash
         env:
-          PLAN_OUTPUT: ${{ steps.plan-prod.outputs.stdout }}
+          PLAN_OUTPUT: ${{ steps.plan-stable.outputs.stdout }}
+          TARGET: ${{ needs.compute_changes.outputs.target }}
         run: |
           {
-            echo "### Production Blueprint Plan"
+            echo "### ${TARGET} Blueprint Plan"
             echo
             printf "%s\n" "$PLAN_OUTPUT"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Deploy production blueprints
-        if: steps.prod-token.outputs.available == 'true'
+      - name: Deploy target blueprints
         uses: ./
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         with:
           command: deploy
-          args: --target prod --blueprints "${{ needs.compute_changes.outputs.changed_csv }}"
+          target: ${{ needs.compute_changes.outputs.target }}
+          blueprints: ${{ needs.compute_changes.outputs.changed_csv }}
+
+  deploy-release-production:
+    name: Deploy Released Production Blueprints
+    needs: compute_changes
+    if: >-
+      github.event_name == 'release' &&
+      needs.compute_changes.outputs.staging_enabled == 'true' &&
+      needs.compute_changes.outputs.deployment_enabled == 'true'
+    runs-on: ubuntu-latest
+    environment: ${{ needs.compute_changes.outputs.target_environment }}
+    concurrency:
+      group: stable-prod
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Verify released commit belongs to the default branch
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "$DEFAULT_BRANCH"
+          release_commit="$(git rev-list -n 1 "$RELEASE_TAG")"
+          git merge-base --is-ancestor "$release_commit" "origin/$DEFAULT_BRANCH" || {
+            echo "Release tag $RELEASE_TAG does not point to a commit on $DEFAULT_BRANCH." >&2
+            exit 1
+          }
+
+      - name: Require production environment token
+        shell: bash
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          TARGET_ENVIRONMENT: ${{ needs.compute_changes.outputs.target_environment }}
+          TARGET_IDENTITY: ${{ needs.compute_changes.outputs.target_identity }}
+        run: |
+          set -euo pipefail
+          if [ -z "$MOTHERDUCK_TOKEN" ]; then
+            echo "Target prod expects GitHub Environment '$TARGET_ENVIRONMENT' to contain a MOTHERDUCK_TOKEN secret for $TARGET_IDENTITY." >&2
+            exit 1
+          fi
+
+      - name: Plan released production blueprints
+        id: plan-production
+        uses: ./
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        with:
+          command: plan
+          target: prod
+          blueprints: ${{ needs.compute_changes.outputs.changed_csv }}
+
+      - name: Summarize production plan
+        shell: bash
+        env:
+          PLAN_OUTPUT: ${{ steps.plan-production.outputs.stdout }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          {
+            echo "### Production Blueprint Plan for ${RELEASE_TAG}"
+            echo
+            printf "%s\n" "$PLAN_OUTPUT"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Deploy released production blueprints
+        uses: ./
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        with:
+          command: deploy
+          target: prod
+          blueprints: ${{ needs.compute_changes.outputs.changed_csv }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,11 @@ This repository contains MotherDuck Blueprints for Dives, Flights, shares, and G
 
 ## Token Handling
 
-Never invent, print, or commit MotherDuck tokens. Local Dives preview uses `.dive-preview/.env`, which is ignored by Git. CI uses the `MOTHERDUCK_TOKEN` repository secret. Shared repositories should use a MotherDuck service account token so deployments are not tied to a personal account.
+Never invent, print, or commit MotherDuck tokens. Local Dives preview uses `.dive-preview/.env`, which is ignored by Git. CI reads `MOTHERDUCK_TOKEN` from the GitHub Environment declared by the selected target; repository-level deployment secrets are deprecated. Shared repositories should use a MotherDuck service account token so deployments are not tied to a personal account.
 
 ## Project Layout
 
-`motherduck.yml` is the canonical repository manifest. It discovers packages below `flights/`, `dives/`, `guides/`, `roles/`, `projects/`, and the compatibility `blueprints/` root, defines shared variables, and declares the `preview` and `prod` targets.
+`motherduck.yml` is the canonical repository manifest. It discovers packages below `flights/`, `dives/`, `guides/`, `roles/`, `projects/`, and the compatibility `blueprints/` root, defines shared variables, and declares the required `preview` and `prod` targets plus optional `staging`.
 
 Each deployable package has a `blueprint.yml`, source files, and a package README. Use typed roots when ownership follows the resource type:
 
@@ -41,7 +41,7 @@ For Dives, keep `export const REQUIRED_DATABASES = ...` on one line in source wh
 
 ## Targets
 
-Preview deployments are branch-scoped. Preview share/database names that may be cleaned up must include `${target.branch_slug}`. Production names are stable and deploy through the `motherduck-production` GitHub Environment.
+Preview deployments are branch-scoped. Preview share/database names that may be cleaned up must include `${target.branch_slug}`. Without staging, `main` deploys production. With `targets.staging`, previews and `main` use the staging service account and a published release deploys production. Staging shares must differ from production shares; their database names may match.
 
 Preview Flight schedules are disabled by target policy. Use `runOnDeploy: true` when a preview or production deploy should start an immediate run. Use `waitForRun: success` when dependent Dives should wait for the Flight run to succeed before resolving shares.
 
@@ -72,7 +72,9 @@ make preview-smoke <blueprint-name>
 make render-preview <blueprint-name>
 ```
 
-CI installs the local `md-blueprints` package and calls the package command for change detection, validation, preview/prod deployment, and preview cleanup. `tools/md_blueprints` remains as a compatibility wrapper for existing local commands.
+CI installs the local `md-blueprints` package and calls the package command for change detection, validation, preview/staging/prod deployment, and preview cleanup. `tools/md_blueprints` remains as a compatibility wrapper for existing local commands.
+
+The GitHub Action defaults to validation. Prefer named `target`, `branch`, `blueprints`, and `root` inputs in workflows; reserve `args` for advanced flags. Keep customer READMEs focused on the first deployment and put detailed options in `docs/`.
 
 ## Changelog
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Update this file in every pull request. Add entries under `Unreleased` until the
 
 ### Fixed
 
+- Allow environment-migration pull requests to finish validation with deployment disabled when the base branch has no environment metadata; live deployments still require complete configuration.
+
 - Reject empty explicit blueprint selections so they cannot accidentally deploy or clean up the entire repository.
 - Make Doctor validate rendered resources and return failure for invalid or missing projects.
 - Share bounded, deduplicated manifest discovery between validation and migration; validate all migrated documents before writing any changes and reject missing schema versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,22 @@ Update this file in every pull request. Add entries under `Unreleased` until the
 
 ## Unreleased
 
+### Fixed
+
+- Reject empty explicit blueprint selections so they cannot accidentally deploy or clean up the entire repository.
+- Make Doctor validate rendered resources and return failure for invalid or missing projects.
+- Share bounded, deduplicated manifest discovery between validation and migration; validate all migrated documents before writing any changes and reject missing schema versions.
+- Prevent scaffolding through symlinks outside the project, and preserve the selected Dive source when preview selection fails.
+- Reuse existing virtual environments during CLI installation instead of recreating them with a potentially different Python interpreter.
+- Avoid redundant deployment rendering and use efficient duplicate detection and deterministic graph ordering.
+
 ### Added
 
+- Added named GitHub Action inputs for target, branch, blueprint selection, and repository root; validation works without a `with` block and existing `args` workflows remain supported.
+
+- Added optional conventional `staging` targets, environment-scoped service-account deployments, and release-driven production promotion when staging is configured.
+- Added validation that staging and production shares render to distinct names while allowing identical database names across service-account environments.
+- Added Blueprints Doctor diagnostics for legacy repository-secret workflows and missing target environment or identity metadata.
 - Added an end-to-end Guides-as-code how-to covering scaffolding, branch-scoped previews, access, references, planning, deployment, and troubleshooting.
 - Added a project-pattern walkthrough for the NCS Field Recovery Explorer.
 - Added PyPI and GitHub Release package distribution, release provenance attestations, SBOM publication, and multi-version CI coverage.
@@ -15,12 +29,21 @@ Update this file in every pull request. Add entries under `Unreleased` until the
 
 ### Changed
 
+- Simplified the tooling and customer READMEs around a browser-first example deployment, with optional local setup and advanced configuration in linked guides.
+- Replaced the empty-commit onboarding example with an actual package edit, clarified environment approval and example deployment behavior, and shortened the customer PR checklist.
+- Updated generated and maintained workflows to use literal named action inputs instead of quoted CLI strings.
+
+- Changed generated CI/CD to derive its behavior from the presence of `targets.staging`: `main` deploys production without staging, while staged repositories deploy `main` to staging and published releases to production.
+- Moved generated deployment credentials from repository-level secrets to target-selected GitHub Environment secrets named `MOTHERDUCK_TOKEN`.
+- Made validation render every declared target and made preview cleanup compare against staging when staging is configured.
+- Made the local and generated Makefiles accept `PYTHON=<interpreter>` so validation can pin a supported Python instead of relying on the machine's default.
 - Expanded the root, repository, setup, Guide package, and generated-template documentation to surface Guide deployment and the NCS public-data example.
 - Pinned generated workflows to the same immutable release tag as their local CLI instead of a floating action tag.
 - Hardened release ordering, external preflight, post-publish canaries, dependency installation, and repository policy checks.
 
 ### Fixed
 
+- Updated the Dive preview lockfiles to resolve the high-severity `nanoid` zero-size generator advisory detected by the required dependency audit.
 - Made the compatibility matrix install the complete test dependency set, retained Python 3.10 resource traversal support, and audited dependencies with the repository's constrained packaging toolchain.
 - Prevented template publication from racing the floating action tag and prevented unreleased source changes from rebuilding an already released package version.
 - Made all typed scaffolds emit YAML-safe strings for reserved slugs and aliases, derive valid SQL aliases for numeric-leading blueprint names, normalize external-share URLs, and reject explicitly empty aliases.

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,11 @@
 
 ARG := $(word 2,$(MAKECMDGOALS))
 CLI := .venv/bin/md-blueprints
+PYTHON ?= python3
 
-$(CLI): pyproject.toml $(shell find src/md_blueprints -type f 2>/dev/null)
-	python3 -m venv .venv
+# Editable installs read source changes directly; only package metadata needs reinstalling.
+$(CLI): pyproject.toml
+	@test -x .venv/bin/python || $(PYTHON) -m venv .venv
 	.venv/bin/python -m pip install -e .
 
 # -- Local development --------------------------------------------------------
@@ -18,20 +20,20 @@ setup: $(CLI) ## Install CLI, Dive preview dependencies, and create .env from ex
 
 .PHONY: install-deploy
 install-deploy: ## Install CLI with live MotherDuck deploy dependencies
-	python3 -m venv .venv
+	@test -x .venv/bin/python || $(PYTHON) -m venv .venv
 	.venv/bin/python -m pip install -e ".[deploy]"
 
 .PHONY: preview
-preview: ## Preview a blueprint Dive locally (e.g. make preview wikipedia-pageviews)
+preview: $(CLI) ## Preview a blueprint Dive locally (e.g. make preview wikipedia-pageviews)
 	@test -n "$(ARG)" || { echo "Usage: make preview <blueprint-name>"; exit 1; }
-	@SOURCE="$$( $(CLI) dive-source --blueprints "$(ARG)" $(if $(DIVE),--dive "$(DIVE)") )"; \
+	@SOURCE="$$( $(CLI) dive-source --blueprints "$(ARG)" $(if $(DIVE),--dive "$(DIVE)") )" && \
 	  echo "export { default, REQUIRED_DATABASES } from \"../../$${SOURCE%.tsx}\";" > .dive-preview/src/dive.tsx
 	cd .dive-preview && npm run dev
 
 .PHONY: preview-smoke
-preview-smoke: ## Build a blueprint Dive preview without starting a dev server
+preview-smoke: $(CLI) ## Build a blueprint Dive preview without starting a dev server
 	@test -n "$(ARG)" || { echo "Usage: make preview-smoke <blueprint-name>"; exit 1; }
-	@SOURCE="$$( $(CLI) dive-source --blueprints "$(ARG)" $(if $(DIVE),--dive "$(DIVE)") )"; \
+	@SOURCE="$$( $(CLI) dive-source --blueprints "$(ARG)" $(if $(DIVE),--dive "$(DIVE)") )" && \
 	  echo "export { default, REQUIRED_DATABASES } from \"../../$${SOURCE%.tsx}\";" > .dive-preview/src/dive.tsx
 	cd .dive-preview && { test -x node_modules/.bin/vite || npm install; }
 	cd .dive-preview && npm run build

--- a/README.md
+++ b/README.md
@@ -1,170 +1,75 @@
 # MotherDuck Blueprints
 
-MotherDuck Blueprints lets you manage MotherDuck resources the same way you manage application code: in a Git repository, reviewed through pull requests, and deployed by CI.
+Deploy MotherDuck data pipelines and dashboards from a GitHub repository.
 
-A blueprint is an independently deployable package with a `blueprint.yml` manifest next to its source. Typed roots make [Flights](https://motherduck.com/docs/concepts/flights/), [Dives](https://motherduck.com/docs/key-tasks/ai-and-motherduck/dives/), Guides, and RBAC roles easy to find; explicit inputs and outputs connect packages that share data. From there:
+**Open a pull request → try a preview → merge to deploy production.**
 
-- **Pull requests** validate every blueprint, deploy branch-scoped previews, and leave a comment on the PR with the deployment plan and preview links.
-- **Merges to `main`** deploy stable production resources through a protected GitHub Environment.
-- **Branch cleanup** removes preview resources when the branch is deleted.
+## Start here
 
-Dive governance travels with the code: previews are always `draft`, while production manifests can declare `ready`, `endorsed`, or `archived`. Deployment plans show live-to-desired status transitions before anything changes.
+[Create a repository from the template](https://github.com/motherduckdb/blueprints-template/generate), choose a private repository, then follow the steps below in your new repository. The workflows and public-data examples are already included.
 
-## What's in this repository
+## Deploy the example
 
-This repository is the source for the Blueprints tooling. As a user, you interact with two versioned surfaces built from it:
+You need a MotherDuck service-account token and permission to configure your GitHub repository. No local installation is required.
 
-| Artifact | What it is |
-| --- | --- |
-| [`motherduckdb/blueprints-template`](https://github.com/motherduckdb/blueprints-template) | A GitHub template repository — the fastest way to start. It is generated from this repository on each release, so don't open pull requests there. |
-| `motherduckdb/motherduck-blueprints@v0.4.1` | The GitHub Action and CLI source for validating, planning, deploying, and migrating blueprints. Generated workflows and local setup use the same immutable release. |
+1. In GitHub, open **Settings → Environments**, create `motherduck-production`, and add your token as an environment secret named `MOTHERDUCK_TOKEN`.
+2. Open [`flights/wikipedia-pageviews-ingest/blueprint.yml`](flights/wikipedia-pageviews-ingest/blueprint.yml), change its `description`, and commit the change to a **new branch**. Open a pull request.
+3. Wait for **Deploy Blueprints** to finish. Its PR comment links to your preview dashboard, backed by public Wikipedia pageview data.
+4. Merge the PR to deploy production. Closing the PR removes its preview resources.
 
-## Prerequisites
+If the environment requires approval, approve the deployment in GitHub Actions. Fork pull requests validate but do not deploy.
 
-- Python 3.10 or newer.
-- Git, used to install the versioned CLI source locally.
-- Node.js 20 or newer (only needed to preview Dives locally).
-- A GitHub repository with Actions enabled.
-- A MotherDuck [service account](https://motherduck.com/docs/key-tasks/service-accounts-guide/) token for CI deployments, so deployed resources are owned by automation rather than by one person's account.
+The default setup uses the same service account for previews and production. For separate credentials and release-based production deployment, [add staging](docs/setup-your-repository.md#add-staging-optional).
 
-## Quickstart
+## Make it yours
 
-### 1. Create your repository
+Each `blueprint.yml` describes what to deploy; the source files beside it contain your code. Start by editing the Wikipedia example:
 
-Use the template repository (recommended):
+- [Flight](flights/wikipedia-pageviews-ingest/): Python that loads data and publishes a share.
+- [Dive](dives/wikipedia-pageviews/): the dashboard that reads that share.
 
-```bash
-gh repo create <your-org>/motherduck-blueprints \
-  --template motherduckdb/blueprints-template --private --clone
-cd motherduck-blueprints
-```
+The repository also includes an [NCS field recovery example](projects/ncs-field-recovery/README.md). All included examples can deploy; remove unwanted example packages before your first deployment.
 
-Or generate the same file set with the CLI:
+For local checks, install Python 3.10+ and Git, then run:
 
 ```bash
-python3 -m venv .venv
-.venv/bin/python -m pip install "md-blueprints==0.4.1"
-.venv/bin/md-blueprints init motherduck-blueprints
-cd motherduck-blueprints
+make validate
 ```
 
-### 2. Try it locally, without a MotherDuck token
+To build the example dashboard locally, also install Node.js 22+:
 
 ```bash
 make setup
-make validate
 make preview-smoke wikipedia-pageviews
 ```
 
-The repository ships with two working public-data examples:
+These checks do not need a MotherDuck token. A preview build checks the dashboard; it does not open a live preview.
 
-- [Wikipedia Pageviews](docs/examples/wikipedia-pageviews.md) demonstrates independently owned Flight producer and Dive consumer packages connected by a named output.
-- [NCS Field Recovery Explorer](projects/ncs-field-recovery/README.md) demonstrates a complete project whose Flight, share, and Dive deploy and roll back together.
-
-### 3. Connect MotherDuck
-
-1. Add a GitHub Actions secret named `MOTHERDUCK_TOKEN` containing your service account token.
-2. Create a GitHub Environment named `motherduck-production` with required reviewers.
-3. Open a small pull request and confirm the preview deployment comment appears.
-4. Merge after review to deploy production through the protected environment.
-
-See [Set Up Your Repository](docs/setup-your-repository.md) for the full setup flow and [GitHub Setup](docs/github-setup.md) for the GitHub checklist.
-
-## Add a Blueprint
-
-Use the root that matches the package's ownership boundary:
-
-```text
-flights/   # producers, shares, and named outputs
-dives/     # dashboards with declared inputs
-guides/    # version-controlled agent context
-roles/     # production RBAC roles and memberships
-projects/  # resources that genuinely ship together
-shared/    # human convention; no deployment behavior
-```
-
-Create a producer and consumer:
+Create your own data pipeline and dashboard with:
 
 ```bash
-make new-flight events-ingest
-make new-dive events-dashboard INPUT=events-ingest.data
-make validate
-make preview-smoke events-dashboard
-```
-
-Use `make new-project revenue-overview` when a Flight and Dive genuinely preview and roll back as one unit. Existing `blueprints/<name>/` repositories remain supported indefinitely; no migration is required.
-
-Guide packages can publish versioned Markdown with catalog, Dive, Flight, and Guide references. Role packages and share grants provide declarative RBAC; admin-only operations run a capability preflight before any mutation.
-
-Create a Guide package and validate it without publishing:
-
-```bash
-make new-guide revenue-metrics
+make new-project revenue
 make validate
 ```
 
-When the content is ready, follow [Manage Guides as code](docs/guides-as-code.md) to enable deployment, add branch-scoped previews, and attach resource references.
+Edit the generated files in `projects/revenue/`, then open a pull request.
 
-Once a MotherDuck token is configured, you can inspect live create/update/delete actions before applying them:
+## More help
 
-```bash
-.venv/bin/md-blueprints plan --target preview --branch feature/example --blueprints events-dashboard
-.venv/bin/md-blueprints cleanup --dry-run --target preview --branch feature/example --blueprints events-dashboard
-```
+- [Setup and troubleshooting](docs/setup-your-repository.md)
+- [Blueprint fields and options](docs/blueprint-yml-reference.md)
+- [GitHub Action inputs](docs/github-action.md)
+- [Guides as code](docs/guides-as-code.md) · [Repository reference](docs/repository-reference.md) · [Upgrades](docs/tooling-and-schema-versioning.md)
 
-## How deployments work
+## Using the action in an existing repository
 
-Every pull request gets a comment with the deployment plan and preview links:
-
-```md
-### Preview Blueprints
-
-| Blueprint | Type | Key | Name | Action |
-| --- | --- | --- | --- | --- |
-| wikipedia-pageviews | flight | loader | wikipedia-pageviews:feature/example (Preview) | create |
-```
-
-- **Preview** deployments are branch-scoped: preview share and database names include the branch slug, Flight schedules are disabled, and resources are cleaned up when the branch goes away.
-- **Production** deployments run only from `main`, through the `motherduck-production` GitHub Environment, so you can require manual approval before anything changes.
-- **Dive status** is reconciled only when declared. Omitting it preserves the live status; setting `endorsed` requires an organization-admin deployment identity.
-- **Dependency selection** expands both upstream and downstream for preview. Production expands downstream only, so a consumer-only change does not rerun an unchanged producer.
-
-## Versioning and upgrades
-
-Your repository pins the tooling in two places: an exact action tag in `.github/workflows/` and the matching exact CLI version in the generated `Makefile`. Upgrade both together; the scheduled Blueprints Doctor opens an issue when a newer release exists or the pins drift.
+Once your repository has a `motherduck.yml` manifest and blueprints, this step validates them:
 
 ```yaml
+- uses: actions/checkout@v7
 - uses: motherduckdb/motherduck-blueprints@v0.4.1
-  with:
-    command: validate
 ```
 
-Every release requires an explicit action and CLI pin update so CI and local behavior cannot diverge. Major releases can also introduce a new manifest `schemaVersion`; run `md-blueprints doctor` and `md-blueprints migrate --to latest` first. See [Tooling and Schema Versioning](docs/tooling-and-schema-versioning.md) for the compatibility policy.
+Validation is the default. Deployment uses `command: deploy` and named inputs such as `target: prod`. See the [action guide](docs/github-action.md) for a complete workflow.
 
-For live local `plan`, `deploy`, and `cleanup` commands, install the deploy extra from the pinned repository tag:
-
-```bash
-make install-deploy
-```
-
-## Best practices
-
-- Use typed roots for independently owned assets and `projects/` only for resources that truly ship together.
-- Declare same-repository dependencies through `inputs` and `outputs`; use literal share URLs across repositories.
-- Use lowercase slug names such as `account-360` or `revenue-ops`.
-- Run a deployment plan before live deploys and use cleanup dry-runs before deleting previews.
-- Deploy from CI with a service account token; store secrets in GitHub Actions, never in the repo.
-
-## Learn more
-
-- [Repository Reference](docs/repository-reference.md): layout, targets, local commands, CI/CD, and context-layer notes.
-- [blueprint.yml Reference](docs/blueprint-yml-reference.md): complete field reference for blueprint manifests.
-- [Manage Guides as code](docs/guides-as-code.md): scaffold, preview, reference, and deploy version-controlled Guides.
-- [Tooling and Schema Versioning](docs/tooling-and-schema-versioning.md): CLI/action pinning, schema compatibility, and migrations.
-- [Wikipedia Pageviews example](docs/examples/wikipedia-pageviews.md): the end-to-end example blueprint.
-- [NCS Field Recovery Explorer](docs/examples/ncs-field-recovery.md): a complete public-data project with a Flight, share, and Dive.
-- [MotherDuck documentation](https://motherduck.com/docs/getting-started) and the [MotherDuck Community Slack](https://slack.motherduck.com/) for product questions and support.
-
-## Contributing
-
-Issues and pull requests are welcome in this repository — see [CONTRIBUTING.md](CONTRIBUTING.md). Don't open pull requests against `blueprints-template`; it is regenerated on each release. To report a security issue, see [SECURITY.md](SECURITY.md).
+This is the tooling source repository. For contributions, see [CONTRIBUTING.md](CONTRIBUTING.md); report tooling bugs here, not in the generated template.

--- a/action.yml
+++ b/action.yml
@@ -9,10 +9,22 @@ branding:
 inputs:
   command:
     description: CLI command to run, such as init, validate, render, changed, plan, deploy, cleanup, doctor, or migrate.
-    required: true
+    required: false
     default: validate
+  target:
+    description: Deployment target (preview, prod, or a configured staging target).
+    required: false
+  branch:
+    description: Branch name for preview resources. Required when target is preview.
+    required: false
+  blueprints:
+    description: Comma-separated package names. Leave empty to select all packages.
+    required: false
+  root:
+    description: Directory containing motherduck.yml, relative to the checkout.
+    required: false
   args:
-    description: Additional command arguments.
+    description: Advanced CLI arguments. Named inputs take precedence over matching flags.
     required: false
     default: ""
   python-version:
@@ -68,6 +80,10 @@ runs:
       env:
         MD_BLUEPRINTS_COMMAND: ${{ inputs.command }}
         MD_BLUEPRINTS_ARGS: ${{ inputs.args }}
+        MD_BLUEPRINTS_TARGET: ${{ inputs.target }}
+        MD_BLUEPRINTS_BRANCH: ${{ inputs.branch }}
+        MD_BLUEPRINTS_BLUEPRINTS: ${{ inputs.blueprints }}
+        MD_BLUEPRINTS_ROOT: ${{ inputs.root }}
       run: |
         set -euo pipefail
         stdout_file="$(mktemp)"
@@ -83,6 +99,10 @@ runs:
             os.environ["MD_BLUEPRINTS_COMMAND"],
             *shlex.split(os.environ.get("MD_BLUEPRINTS_ARGS", "")),
         ]
+        for name in ("root", "target", "branch", "blueprints"):
+            value = os.environ.get(f"MD_BLUEPRINTS_{name.upper()}", "")
+            if value:
+                argv.append(f"--{name}={value}")
         completed = subprocess.run(argv, text=True, stdout=subprocess.PIPE, check=False)
         sys.stdout.write(completed.stdout)
         raise SystemExit(completed.returncode)
@@ -90,8 +110,10 @@ runs:
         status="${PIPESTATUS[0]}"
         set -e
         {
-          echo "stdout<<MD_BLUEPRINTS_EOF"
+          delimiter="MD_BLUEPRINTS_$(python -c 'import uuid; print(uuid.uuid4().hex)')"
+          echo "stdout<<$delimiter"
           cat "$stdout_file"
-          echo "MD_BLUEPRINTS_EOF"
+          echo
+          echo "$delimiter"
         } >> "$GITHUB_OUTPUT"
         exit "$status"

--- a/docs/blueprint-yml-reference.md
+++ b/docs/blueprint-yml-reference.md
@@ -116,6 +116,8 @@ resources:
       cleanup: true
       dropDatabase: false
       targets:
+        staging:
+          name: events_staging
         preview:
           name: events${var.preview_suffix}
           database: events${var.preview_suffix}
@@ -126,7 +128,7 @@ resources:
 
 Required fields are `name` and `database`. Defaults are `access: ORGANIZATION`, `visibility: DISCOVERABLE`, `cleanup: true`, and `dropDatabase: false`.
 
-A hidden share must use restricted access. With the default preview policy, cleanup-sensitive share and database names must contain `target.branch_slug`.
+A hidden share must use restricted access. With the default preview policy, cleanup-sensitive share and database names must contain `target.branch_slug`. When `targets.staging` exists, every rendered staging share name must differ from every production share name. Staging and production database names may match because they belong to separate service accounts.
 
 `includePattern` manages the filtered-share include list. An omitted field leaves the current filter unmanaged, `null` resets the share to unfiltered, and an empty array includes nothing. `grants.roles` and `grants.users` manage `READ` grants. `mode: additive` preserves undeclared grantees, while `mode: authoritative` revokes them.
 
@@ -224,16 +226,16 @@ resources:
       deploy: true
 ```
 
-Roles deploy only to production and require an admin deployment identity. `includedRoles` are roles inherited by the custom role; `members` are MotherDuck usernames. `mode: additive` preserves assignments not listed in the manifest. `mode: authoritative` revokes undeclared direct role and user memberships. Blueprints never delete roles automatically.
+Roles deploy to stable staging and production targets and require an admin deployment identity. They never deploy to preview. `includedRoles` are roles inherited by the custom role; `members` are MotherDuck usernames. `mode: additive` preserves assignments not listed in the manifest. `mode: authoritative` revokes undeclared direct role and user memberships. Blueprints never delete roles automatically.
 
 ## Target and Deployment Semantics
 
-Every resource accepts a `targets.<target>` override. Preview and production rendering validate uniqueness for Flight names, Dive titles, deployed Guide identities, role names, and share names.
+Every resource accepts a `targets.<target>` override. All declared targets validate uniqueness for Flight names, Dive titles, deployed Guide identities, role names, and share names. Staging additionally validates that its share names do not collide with production.
 
 Inputs and repository-local Guide references form a DAG:
 
 - Preview selection expands recursively upstream and downstream.
-- Production selection expands recursively downstream only.
+- Stable staging and production selection expand recursively downstream only.
 - Producers deploy before consumers.
 - A consumer-only production plan requires the producer's output to exist in MotherDuck and fails before mutation otherwise.
 - Cleanup runs in reverse dependency order.

--- a/docs/examples/ncs-field-recovery.md
+++ b/docs/examples/ncs-field-recovery.md
@@ -61,7 +61,7 @@ make install-deploy
   --blueprints ncs-field-recovery
 ```
 
-Opening a pull request runs the same selection through GitHub Actions. Preview database, share, Flight, and Dive names include the branch scope, and cleanup removes them after the branch closes. The production target uses stable names and runs through the protected `motherduck-production` environment.
+Opening a pull request runs the same selection through GitHub Actions. Preview database, share, Flight, and Dive names include the branch scope, and cleanup removes them after the branch closes. Without staging, merging deploys the stable production target. With staging, merging deploys the `_staging` share through `motherduck-staging`, and a published release deploys the unsuffixed production share through `motherduck-production`. Both accounts may use the `ncs_field_recovery` database name.
 
 ## Reuse the pattern
 
@@ -73,7 +73,7 @@ make new-project field-analytics
 
 Then carry over the patterns that fit your project:
 
-- Use target variables for stable production names and branch-scoped preview names.
+- Use target overrides for distinct staging/production share names and branch-scoped preview names.
 - Set `runOnDeploy: true` when a deployment needs fresh data.
 - Set `waitForRun: success` when downstream resources must wait for the Flight.
 - Keep source-specific metric definitions and limitations in the package README.

--- a/docs/examples/wikipedia-pageviews.md
+++ b/docs/examples/wikipedia-pageviews.md
@@ -63,7 +63,7 @@ For branch `feature/mock-test`, the share and database render as:
 wikipedia_pageviews_preview_feature_mock_test
 ```
 
-In production, a producer change also redeploys the Dive and reconciles its declared `ready` status. A Dive-only change uses the existing production output and does not rerun the Flight.
+In a stable target, a producer change also redeploys the Dive and reconciles its declared `ready` status. A Dive-only change uses the existing output and does not rerun the Flight. If staging is configured, the staging share renders as `wikipedia_pageviews_staging` while its database remains `wikipedia_pageviews`; a published release deploys the unsuffixed production share.
 
 Cleanup reverses dependencies: it removes the Dive before the Flight, share, and preview database.
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -1,0 +1,74 @@
+# Use the GitHub Action
+
+The template already includes deployment and cleanup workflows. You do not need to write a workflow to use it.
+
+Use the action directly when adding Blueprints to an existing repository with a `motherduck.yml` manifest.
+
+## Validate pull requests
+
+Save this as `.github/workflows/validate.yaml`:
+
+```yaml
+name: Validate Blueprints
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: motherduckdb/motherduck-blueprints@v0.4.1
+```
+
+The action installs its own Python dependencies. Validation is the default command and needs no token.
+
+## Deploy manually
+
+Create the `motherduck-production` GitHub Environment and add your service-account token as its `MOTHERDUCK_TOKEN` secret. Save this as `.github/workflows/deploy.yaml`:
+
+```yaml
+name: Deploy Blueprints
+on: [workflow_dispatch]
+permissions:
+  contents: read
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: motherduck-production
+    concurrency:
+      group: motherduck-production
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v7
+      - uses: motherduckdb/motherduck-blueprints@v0.4.1
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        with:
+          command: deploy
+          target: prod
+```
+
+Run it from **Actions → Deploy Blueprints → Run workflow**. It deploys all packages and checks the deployment plan before applying changes. To deploy a subset, add `blueprints: revenue`.
+
+This minimal workflow runs only when you request it. For automatic PR previews, comments, and cleanup, use the template's existing workflows.
+
+## Inputs
+
+| Input | Default | Purpose |
+| --- | --- | --- |
+| `command` | `validate` | CLI command, such as `plan`, `deploy`, `cleanup`, or `doctor`. |
+| `target` | Command default | `prod` for deploy/plan; `preview` for cleanup; validation checks every target. |
+| `branch` | Empty | Required for preview deployment and cleanup. Pass the branch name directly; no extra quotes are needed. |
+| `blueprints` | All packages | Comma-separated package names, such as `orders,revenue`. Dependencies expand according to the target. |
+| `root` | Checkout directory | Directory containing `motherduck.yml`, such as `analytics`. |
+| `args` | Empty | Advanced CLI flags, such as `--json`, `--offline`, or `--dry-run`. |
+| `python-version` | `3.11` | Python runtime installed by the action. |
+
+Named inputs override matching flags in `args`. Existing workflows using only `args` continue to work. The action passes named inputs as literal argument values, including spaces and quotes.
+
+Live commands read `MOTHERDUCK_TOKEN` from the step environment. Select the GitHub Environment on the **job**; the action's `target` input does not select a GitHub Environment for you.
+
+The `stdout` output contains the command's text or JSON result. Assign an `id` to the step to read `steps.<id>.outputs.stdout`. Command failures fail the step.
+
+Pin the action and your local CLI to the same release. See [upgrades](tooling-and-schema-versioning.md).

--- a/docs/github-setup.md
+++ b/docs/github-setup.md
@@ -1,97 +1,21 @@
-# GitHub Setup
+# Protect your GitHub repository
 
-## 1. Create the Repository
+Complete the [first deployment](setup-your-repository.md) before adding required checks, so GitHub can list the workflow names.
 
-Prefer generating your repository with `md-blueprints init`. See [setup-your-repository.md](setup-your-repository.md) for the full generation and push flow.
+## Protect main
 
-If you are pushing from a local copy manually, create an empty GitHub repository named `motherduck-blueprints`, then push this folder to it.
+In **Settings → Branches** (or your repository rulesets), require pull requests, reviews, and the validation checks before merging to `main`. If you enable Code Owner reviews, first replace the examples in `.github/CODEOWNERS` with your own users or teams.
 
-```bash
-git init
-git add .
-git commit -m "Initial MotherDuck Blueprints repo"
-git branch -M main
-git remote add origin git@github.com:<your-org>/motherduck-blueprints.git
-git push -u origin main
-```
+## Require deployment approval
 
-## 2. Add MotherDuck Secret
+Open **Settings → Environments → motherduck-production** and add required reviewers if your team needs deployment approval.
 
-In GitHub:
+In the default setup, previews, production, and cleanup all use this environment, so its approval and branch rules apply to all three. Allow PR branches if you want previews to deploy. To approve production separately, [add staging](setup-your-repository.md#add-staging-optional).
 
-1. Open Settings.
-2. Open Secrets and variables, then Actions.
-3. Create a repository secret named `MOTHERDUCK_TOKEN`.
-4. Paste a MotherDuck read/write token.
+## Keep credentials and cleanup configured
 
-Use a service account token so deployed resources are owned by automation rather than by an individual user.
+Store `MOTHERDUCK_TOKEN` as an environment secret containing a MotherDuck service-account read/write token. Same-repository deployments fail with a configuration message if it is missing. Fork PRs validate without secrets.
 
-## 3. Add Production Environment Approval
+Keep **Cleanup Preview Blueprints** enabled. It removes preview resources on PR close or branch deletion, checking both branch and base manifests on PR close.
 
-In GitHub:
-
-1. Open Settings.
-2. Open Environments.
-3. Create an environment named `motherduck-production`.
-4. Add required reviewers.
-
-Production blueprint deploys target this environment, so GitHub pauses deployment until an approved reviewer allows it.
-
-## 4. Protect Main
-
-In GitHub:
-
-1. Open Settings.
-2. Open Branches.
-3. Add a branch protection rule for `main`.
-4. Enable "Require a pull request before merging".
-5. Enable required approvals.
-6. Enable "Require review from Code Owners" after updating `.github/CODEOWNERS`.
-7. Require status checks once the first workflow runs have created them.
-
-The repo includes cleanup workflows for preview blueprints. On pull-request close, cleanup checks both the branch and base manifests so resources introduced or removed by the branch are covered. Keep those workflows enabled so PR previews do not linger after branches are closed or deleted.
-
-Pull requests validate even when `MOTHERDUCK_TOKEN` is not configured. Preview deployment is skipped in that case; add the secret when you want PRs to create live MotherDuck previews.
-
-If a target uses a different service account secret, set `targets.<target>.deployment.tokenEnvVar` in `motherduck.yml` and expose that env var in your workflow. The default remains `MOTHERDUCK_TOKEN`.
-
-## 5. Add Assets
-
-Add every deployable asset inside a typed or project package:
-
-```text
-flights/<name>/blueprint.yml
-dives/<name>/blueprint.yml
-guides/<name>/blueprint.yml
-roles/<name>/blueprint.yml
-projects/<name>/blueprint.yml
-```
-
-Use lowercase slug names. No per-package workflow registration is needed: the deploy workflow computes direct changes from `motherduck.yml`, then expands dependencies according to the target.
-
-For a new project, start with:
-
-```bash
-make new-project <blueprint-name>
-```
-
-For separately owned resources, use `make new-flight`, `make new-dive`, `make new-guide`, and `make new-role` instead.
-
-Before opening a PR, run:
-
-```bash
-make setup
-make validate
-make preview-smoke <blueprint-name>
-```
-
-Skip `make preview-smoke` only when the changed blueprint has no Dive.
-For docs-only changes, keep the relevant README or `docs/` page in sync with any behavior you describe.
-
-Live workflows run `md-blueprints plan` before deploy. You can run the same check locally with a MotherDuck token:
-
-```bash
-md-blueprints plan --target preview --branch feature/example --blueprints <blueprint-name>
-```
-
-Pin the exact CLI and action release together when maintaining a customer repository over time. See [Tooling and Schema Versioning](tooling-and-schema-versioning.md) for upgrade and migration guidance.
+For custom workflows, see the [GitHub Action guide](github-action.md). For version updates, see [tooling upgrades](tooling-and-schema-versioning.md).

--- a/docs/guides-as-code.md
+++ b/docs/guides-as-code.md
@@ -139,7 +139,7 @@ Push the branch and open a pull request. The generated workflow:
 4. Adds the Guide ID and deployment plan to the pull request comment.
 5. Deletes the preview Guide when the pull request closes or the branch is deleted.
 
-After review, merge the pull request. The production workflow publishes stable Guide content, references, metadata, and access through the protected `motherduck-production` environment.
+After review, merge the pull request. Without staging, the merge publishes stable Guide content through `motherduck-production`. With `targets.staging`, the merge publishes to staging; create a non-prerelease GitHub Release when the exact tagged content is ready to deploy through `motherduck-production`.
 
 ## Troubleshooting
 

--- a/docs/repository-reference.md
+++ b/docs/repository-reference.md
@@ -98,14 +98,16 @@ Direct Git change detection remains package-based. Graph expansion happens when 
 
 ## Targets and Safety
 
-The default targets are:
+The required targets are:
 
 - `preview`: branch-scoped names, disabled Flight schedules, and cleanup enabled.
 - `prod`: stable names deployed through the `motherduck-production` GitHub Environment.
 
+`staging` is the one optional conventional target. Its presence changes CI/CD from direct production deployment to release promotion: previews and `main` use the staging service account, while published releases use production.
+
 Cleanup-sensitive preview shares and databases must contain `${target.branch_slug}`. Preview Flight names and Dive titles must contain the branch or branch slug. Cleanup refuses identifiers that are not branch-scoped or that match production.
 
-A target can select a token environment variable and document its deployment identity:
+A target declares the GitHub Environment that holds its service-account token and documents that identity:
 
 ```yaml
 targets:
@@ -117,6 +119,10 @@ targets:
 ```
 
 Tokens are passed to the DuckDB connection and are never printed.
+
+The default `preview + prod` topology points both targets at `motherduck-production` and deploys `main` directly to production. To isolate production, add `staging`, point both `preview` and `staging` at `motherduck-staging`, and keep `prod` on `motherduck-production`. Each GitHub Environment contains its own secret named `MOTHERDUCK_TOKEN`.
+
+Staging and production may render the same database names because the databases belong to different service accounts. Their share names must differ; Blueprints validates this across every rendered share when staging is configured. A `_staging` suffix is the default scaffold convention. Use a customer-specific logical prefix to reduce the chance of a collision outside the repository.
 
 ## Local Commands
 
@@ -137,9 +143,11 @@ md-blueprints cleanup --dry-run --target preview --branch feature/local
 md-blueprints doctor
 ```
 
+Omit `--blueprints` to select all packages; an explicitly empty selection is an error. `doctor` validates all declared targets, including rendered resources, and exits unsuccessfully if the manifest is missing or validation fails. Preview commands preserve the existing Dive entrypoint if source selection fails.
+
 `make new-blueprint NAME` remains a compatibility alias for `make new-project NAME`. For a Dive backed by another repository, use `make new-dive NAME URL=md:_share/...`. If a package declares several Dives, pass `DIVE=<resource-key>` to preview commands.
 
-`make validate` renders preview and production, validates contracts and uniqueness, checks Flight Python syntax and source boundaries, and validates Dive mounts and Guide references. `md-blueprints plan` queries live state without mutations. A non-selected production producer must already expose its declared share or planning fails before deployment.
+`make validate` renders every declared target, validates contracts and uniqueness, checks Flight Python syntax and source boundaries, and validates Dive mounts and Guide references. `md-blueprints plan` queries live state without mutations. A non-selected stable producer must already expose its declared share or planning fails before deployment.
 
 ## Dives
 
@@ -153,11 +161,11 @@ See [Manage Guides as code](guides-as-code.md) for the end-to-end workflow, incl
 
 ## RBAC
 
-Declare custom roles under `resources.roles` or scaffold a role package with `make new-role`. Roles deploy only in production, before resources that may grant access to them. Share `grants` can target roles and users in additive or authoritative mode. Role and organization-Guide changes run an admin capability preflight before the first mutation.
+Declare custom roles under `resources.roles` or scaffold a role package with `make new-role`. Roles deploy to stable staging and production targets, but never to preview, before resources that may grant access to them. Share `grants` can target roles and users in additive or authoritative mode. Role and organization-Guide changes run an admin capability preflight before the first mutation.
 
 ## CI/CD
 
-Pull requests compute directly changed packages, expand the preview dependency graph, plan live changes, deploy branch-scoped resources, and comment with plans and preview links. Pushes to `main` expand production changes downstream and deploy through the protected production environment. Closing a PR or deleting a branch triggers dependency-safe preview cleanup.
+Pull requests compute directly changed packages, expand the preview dependency graph, plan live changes, deploy branch-scoped resources, and comment with plans and preview links. Without staging, pushes to `main` expand changes downstream and deploy production. With staging, pushes to `main` deploy staging and a published non-prerelease GitHub Release verifies and deploys the exact tagged commit to production. Closing a PR or deleting a branch triggers dependency-safe preview cleanup through the preview target's GitHub Environment.
 
 ## Included examples
 

--- a/docs/setup-your-repository.md
+++ b/docs/setup-your-repository.md
@@ -1,203 +1,121 @@
-# Set Up Your Repository
+# Set up your first deployment
 
-Use `md-blueprints init` to generate a typed MotherDuck Blueprints repository, connect it to MotherDuck with a service account token, then customize or add independently deployable packages.
+Start with the [template repository](https://github.com/motherduckdb/blueprints-template/generate). Choose a private repository. It includes the workflows and public-data examples, so you can try deployment without installing anything locally.
 
-Use `flights/`, `dives/`, `guides/`, and `roles/` when those resources have different owners or lifecycles. Use `projects/` when several resource types genuinely ship, preview, and roll back together. Existing `blueprints/` packages remain supported.
+## 1. Connect MotherDuck
 
-## 1. Generate the Repository
+Create a MotherDuck service account with a read/write token and permission to create the example resources. In your new GitHub repository, open **Settings → Environments**, create `motherduck-production`, and add the token as an environment secret named `MOTHERDUCK_TOKEN`.
 
-Install the released CLI and generate the customer file set:
+The default setup uses this account for both previews and production. Never commit the token. If your GitHub plan does not offer Environments for this repository, resolve that before deploying; these workflows require an environment secret.
+
+## 2. Open your first preview
+
+In GitHub, edit the `description` in `flights/wikipedia-pageviews-ingest/blueprint.yml`. Choose **Create a new branch for this commit** and open a pull request. Start with the Flight package so the first production deployment creates the data before the dashboard.
+
+Wait for **Deploy Blueprints** to finish. It loads public Wikipedia data and posts a comment containing the plan and preview links. Open the Dive link to see the dashboard.
+
+Change an example file for this first PR: an empty commit or a top-level README-only change does not trigger deployment. Fork PRs validate without deployment credentials.
+
+## 3. Deploy production
+
+Merge the PR into `main`. The workflow deploys the changed packages to production and shows its plan in the Actions job summary. Preview resources are cleaned up when the PR closes.
+
+The repository also includes the NCS example under `projects/ncs-field-recovery/`. A manual deployment with no package selection deploys all included examples. Remove unwanted packages before deploying them. Removing source files does not delete already-deployed production resources.
+
+## Work locally (optional)
+
+Install Python 3.10+ and Git, clone your repository, and run:
 
 ```bash
-python3 -m venv .venv
-.venv/bin/python -m pip install "md-blueprints==0.4.1"
-.venv/bin/md-blueprints init motherduck-blueprints
-cd motherduck-blueprints
+make validate
 ```
 
-Create a GitHub repository and push the generated files:
-
-```bash
-git init
-git add .
-git commit -m "Initial MotherDuck Blueprints repo"
-gh repo create <your-org>/motherduck-blueprints --private --source . --remote origin --push
-```
-
-## 2. Create a MotherDuck Service Account Token
-
-In your MotherDuck organization:
-
-1. Create a service account for CI deployments.
-2. Grant it the minimum database privileges needed by the blueprints. Use the `admin` preset role when the repository manages custom roles or organization-wide Guides.
-3. Generate a read/write token.
-4. Store the token somewhere secure long enough to add it to GitHub.
-
-Use a service account token rather than a personal token so deployed Dives, Flights, tables, and shares are owned by a shared automation identity.
-
-## 3. Add GitHub Secrets
-
-In your repository:
-
-1. Open Settings.
-2. Open Secrets and variables, then Actions.
-3. Add a repository secret named `MOTHERDUCK_TOKEN`.
-4. Paste the MotherDuck service account token.
-
-Do not commit tokens to the repository.
-
-## 4. Configure Deployment Approvals
-
-Create a GitHub Environment named `motherduck-production`.
-
-Recommended settings:
-
-- Add required reviewers.
-- Restrict who can approve production deployments if needed.
-- Keep the environment name exactly `motherduck-production`, because production jobs reference it.
-
-## 5. Protect `main`
-
-Add branch protection for `main`.
-
-Recommended settings:
-
-- Require a pull request before merging.
-- Require approvals.
-- Require review from Code Owners after `.github/CODEOWNERS` is updated.
-- Require the relevant workflow checks after the first PR has run them.
-
-## 6. Run Local Validation
-
-Before touching MotherDuck, run:
+For dashboard development, install Node.js 22+ and run:
 
 ```bash
 make setup
-make validate
 make preview-smoke wikipedia-pageviews
 ```
 
-`make validate` checks manifests and rendered targets. `make preview-smoke` builds a selected Dive locally without contacting MotherDuck.
+Validation and preview builds do not connect to MotherDuck. To open a live local preview after deploying the data, set `VITE_MOTHERDUCK_TOKEN` in the ignored `.dive-preview/.env`, then run `make preview wikipedia-pageviews`. Keep this local development token private.
 
-If you keep a Dive in the repo, also run a finite local preview build:
+Create a new pipeline and dashboard with `make new-project revenue`. Edit its files under `projects/revenue/`, run `make validate`, and open a PR. For separate pipeline and dashboard packages, see the [repository reference](repository-reference.md).
 
-```bash
-make preview-smoke <blueprint-name>
-```
+## If something does not work
 
-PR validation still runs if `MOTHERDUCK_TOKEN` has not been added yet, but live preview deployment is skipped until the secret exists.
+| What you see | What to check |
+| --- | --- |
+| No deployment run | Change a file inside an example package and open the PR against `main`. |
+| Waiting for approval | Approve the deployment in Actions if you configured required environment reviewers. |
+| Missing token | Put `MOTHERDUCK_TOKEN` in **Settings → Environments → motherduck-production**, not repository secrets. |
+| Permission error from MotherDuck | Check the service account's privileges. Custom roles and organization-wide Guides require an admin identity. |
+| Local Python setup fails | Select a working interpreter, for example `make validate PYTHON=python3.13`. |
+| No preview comment on a fork PR | Expected: fork PRs validate only. Use a branch in your own repository to deploy. |
 
-## 7. Run a Preview PR
+Before team use, [configure branch protection and deployment approvals](github-setup.md). In the default setup, environment approval rules apply to previews and cleanup as well as production.
 
-Create a branch and make a small change, for example edit the Wikipedia Dive docs or metadata.
+## Add staging (optional)
 
-```bash
-git checkout -b test/wikipedia-blueprint
-git commit --allow-empty -m "Test Wikipedia blueprint preview"
-git push -u origin test/wikipedia-blueprint
-gh pr create --fill
-```
+Add staging when production credentials must not be available to pull requests or ordinary `main` deployments.
 
-Expected preview flow:
-
-1. `Deploy Blueprints` validates manifests.
-2. Directly changed packages are discovered from `motherduck.yml`, then the preview selection expands upstream and downstream.
-3. The workflow runs a read-only preview plan.
-4. Preview Flights deploy with schedules disabled.
-5. Preview Flights run when `runOnDeploy` is true.
-6. Preview databases and shares are created with the branch slug.
-7. Dives deploy after required shares are resolvable.
-8. Preview Dives are enforced as `draft`.
-9. Opt-in preview Guides deploy after their references resolve.
-10. A PR comment lists the plan plus preview Flight, share, Dive, and Guide details.
-
-## 8. Verify Cleanup
-
-Close the PR or delete the branch.
-
-Expected cleanup flow:
-
-1. Preview Guides are deleted.
-2. Preview Dives are deleted.
-3. Preview Flights are deleted.
-4. Preview shares are dropped.
-5. Preview databases are dropped when `dropDatabase: true`.
-
-Cleanup refuses to drop share/database names that do not include the branch slug.
-
-You can preview cleanup locally before closing a PR:
-
-```bash
-md-blueprints cleanup --dry-run --target preview --branch test/wikipedia-blueprint
-```
-
-## 9. Deploy to Production
-
-Merge the PR to `main`.
-
-Expected production flow:
-
-1. `Deploy Blueprints` runs on `main`.
-2. GitHub waits for approval in `motherduck-production`.
-3. The workflow writes a read-only production plan to the GitHub job summary.
-4. Production roles and memberships reconcile.
-5. Production Flights deploy.
-6. Flights run when `runOnDeploy` is true.
-7. Required shares, filters, and grants reconcile.
-8. Production Dives deploy and reconcile explicitly declared governance statuses.
-9. Production Guides deploy after their references resolve.
-
-The generated examples use `ready` in production and `draft` in preview. Omitting production `status` preserves the live value. Endorsing a Dive requires an organization-admin deployment identity.
-
-## 10. Customize the Blueprints
-
-You can then:
-
-- Scaffold a producer with `make new-flight events-ingest` and consume it with `make new-dive events-dashboard INPUT=events-ingest.data`.
-- Scaffold a complete co-owned package with `make new-project revenue-overview`.
-- Connect same-repository packages through `outputs` and `inputs`; use literal share URLs for external repositories.
-- Replace the bundled Wikipedia and NCS public-data examples with your own packages.
-- Add target `deployment.tokenEnvVar` and `deployment.identity` metadata in `motherduck.yml` if preview and production use different service account secrets.
-- Publish versioned Guide assets below `guides/` with `resources.guides` and `deploy: true`; follow [Manage Guides as code](guides-as-code.md) for preview naming, access, and references.
-- Manage custom roles below `roles/` with `resources.roles`; use `mode: authoritative` only when the repository owns the complete membership set.
-- Update `.github/CODEOWNERS`.
-
-## 11. Keep Tooling in Sync
-
-After repository creation, treat the versioned `md-blueprints` repository tags as the long-term upgrade surface. The generated files are the starting point, while the CLI source and action carry schema validation, deployment behavior, and migrations.
-
-The generated `Makefile` pins the CLI version in `CLI_VERSION` and installs it from the matching Git tag, so local installs stay aligned with the release that generated the repository. Install and validate with:
-
-```bash
-make setup
-make validate
-```
-
-Use `make install-deploy` before live local plan/deploy/cleanup commands. It installs the deploy extra, which includes the DuckDB Python runtime dependencies needed for MotherDuck connections:
-
-```bash
-make install-deploy
-```
-
-To upgrade, bump `CLI_VERSION` in `Makefile` and every action tag in `.github/workflows/` to the same exact release. Blueprints Doctor reports newer releases and rejects drift between those pins.
-
-The action tag is the preferred CI path for customer repositories.
-
-When using the repository action, pin the exact release in customer workflows:
+1. Create a second MotherDuck service account for staging.
+2. Create a GitHub Environment named `motherduck-staging` and add its token as an environment secret named `MOTHERDUCK_TOKEN`.
+3. Change `targets.preview.environment` and `targets.preview.deployment.identity` to the staging environment and service account.
+4. Add the conventional staging target:
 
 ```yaml
-- uses: motherduckdb/motherduck-blueprints@v0.4.1
-  with:
-    command: validate
+targets:
+  preview:
+    mode: preview
+    environment: motherduck-staging
+    deployment:
+      tokenEnvVar: MOTHERDUCK_TOKEN
+      identity: GitHub Actions staging service account
+    policies:
+      disableSchedules: true
+      cleanup: true
+      requireBranchSlugInDataResources: true
+
+  staging:
+    mode: production
+    environment: motherduck-staging
+    deployment:
+      tokenEnvVar: MOTHERDUCK_TOKEN
+      identity: GitHub Actions staging service account
+
+  prod:
+    mode: production
+    environment: motherduck-production
+    deployment:
+      tokenEnvVar: MOTHERDUCK_TOKEN
+      identity: GitHub Actions production service account
 ```
 
-Before adopting a new schema version, run:
+5. Give every produced staging share a distinct physical name:
 
-```bash
-md-blueprints doctor
-md-blueprints migrate --to latest
+```yaml
+resources:
+  shares:
+    events:
+      name: acme_events
+      database: events
+      targets:
+        staging:
+          name: acme_events_staging
 ```
 
-Review migration output before applying it with `--write`.
+The database can remain `events` because each service account owns its own database. The share name must differ across staging and production. Use a customer-specific logical prefix because Blueprints can detect collisions between declared targets but cannot inspect unrelated accounts.
 
-When you change repository commands, resource behavior, target policies, or package layout, update the matching docs in the same pull request.
+After staging is present, the workflow changes automatically:
+
+1. Pull requests deploy branch-scoped previews through `motherduck-staging`.
+2. Merges to `main` deploy stable staging resources.
+3. A published, non-prerelease GitHub Release checks out its exact tag and deploys every blueprint to production.
+
+Promotion reconciles the tagged code under the production service account. It does not copy staging databases or data.
+
+## Keep the tooling current
+
+Update `CLI_VERSION` in the generated `Makefile` and the action tags in `.github/workflows/` to the same release. The scheduled Doctor workflow reports outdated tooling and configuration problems. See [upgrades and migrations](tooling-and-schema-versioning.md).
+
+For live local commands, run `make install-deploy` first. For a custom workflow, see [GitHub Action inputs](github-action.md).

--- a/docs/tooling-and-schema-versioning.md
+++ b/docs/tooling-and-schema-versioning.md
@@ -43,6 +43,8 @@ make preview-smoke <blueprint-name>
 
 The scheduled `Blueprints Doctor` workflow runs `doctor --check-updates` and opens or updates one tracking issue when a release is stale, action and CLI pins drift, or the project schema needs migration.
 
+Doctor also reports deployment-model drift. Repository-level `MOTHERDUCK_TOKEN` workflows are deprecated: generated workflows now select the GitHub Environment declared by each target and read that environment's `MOTHERDUCK_TOKEN`. Existing pre-1.0 workflows remain executable during the compatibility window, but the legacy secret model is scheduled for removal at the next major release.
+
 ## Schema Source of Truth
 
 Packaged schemas live under `src/md_blueprints/schemas/v*/`. Repo-local schemas under `schemas/v*/` mirror those files for editors, docs, and agents, but runtime validation uses the packaged schemas.
@@ -91,7 +93,7 @@ The internal migration contract is:
 MIGRATIONS: dict[tuple[int, int], Callable[[dict[str, object]], dict[str, object]]] = {}
 ```
 
-Each migration is a pure document transform. The command loads `motherduck.yml` and included `blueprint.yml` files, applies the migration path, emits a unified diff, optionally writes files, and revalidates migrated documents against the target schema.
+Each migration is a pure document transform. The command loads `motherduck.yml` and included `blueprint.yml` files, applies the migration path, validates every migrated document against the target schema, and emits a unified diff. With `--write`, files are written only after every document passes validation. Includes stay within the repository, overlapping matches are deduplicated, and every document must declare an integer `schemaVersion`. File writes are sequential; an operating-system write failure can still leave a partial migration.
 
 For `schemaVersion: 1`, `md-blueprints migrate --to latest` prints that no migration is needed.
 

--- a/flights/README.md
+++ b/flights/README.md
@@ -1,3 +1,3 @@
 # Flights
 
-Place independently owned Flight producers below this root. A Flight blueprint may declare shares and named outputs for downstream consumers.
+Place independently owned Flight producers below this root. A Flight blueprint may declare shares and named outputs for downstream consumers. If the repository configures staging, give every staging share a distinct physical name such as `<share>_staging`; its database name may stay the same as production.

--- a/flights/wikipedia-pageviews-ingest/blueprint.yml
+++ b/flights/wikipedia-pageviews-ingest/blueprint.yml
@@ -31,6 +31,8 @@ resources:
       cleanup: true
       dropDatabase: false
       targets:
+        staging:
+          name: ${var.share}_staging
         preview:
           name: ${var.share}${var.preview_suffix}
           database: ${var.database}${var.preview_suffix}

--- a/motherduck.yml
+++ b/motherduck.yml
@@ -20,9 +20,10 @@ targets:
   preview:
     mode: preview
     default: true
+    environment: motherduck-production
     deployment:
       tokenEnvVar: MOTHERDUCK_TOKEN
-      identity: GitHub Actions preview service account
+      identity: GitHub Actions production service account
     policies:
       disableSchedules: true
       cleanup: true

--- a/projects/ncs-field-recovery/blueprint.yml
+++ b/projects/ncs-field-recovery/blueprint.yml
@@ -31,6 +31,8 @@ resources:
       cleanup: true
       dropDatabase: false
       targets:
+        staging:
+          name: ${var.share}_staging
         preview:
           name: ${var.share}${var.preview_suffix}
           database: ${var.database}${var.preview_suffix}

--- a/roles/README.md
+++ b/roles/README.md
@@ -1,3 +1,3 @@
 # Roles
 
-Place production RBAC role packages below this root. Role deployment is disabled for preview targets. Use `mode: additive` to preserve undeclared assignments or `mode: authoritative` to revoke assignments not declared in the blueprint.
+Place stable-environment RBAC role packages below this root. Roles deploy to staging and production but remain disabled for preview targets. Use `mode: additive` to preserve undeclared assignments or `mode: authoritative` to revoke assignments not declared in the blueprint.

--- a/schemas/v1/motherduck-root.schema.json
+++ b/schemas/v1/motherduck-root.schema.json
@@ -29,6 +29,7 @@
       "additionalProperties": { "$ref": "#/$defs/target" },
       "properties": {
         "preview": { "$ref": "#/$defs/target" },
+        "staging": { "$ref": "#/$defs/target" },
         "prod": { "$ref": "#/$defs/target" }
       }
     }
@@ -57,7 +58,7 @@
       "properties": {
         "mode": { "type": "string", "minLength": 1 },
         "default": { "type": "boolean" },
-        "environment": { "type": "string" },
+        "environment": { "type": "string", "minLength": 1 },
         "deployment": {
           "type": "object",
           "additionalProperties": false,

--- a/src/md_blueprints/cli.py
+++ b/src/md_blueprints/cli.py
@@ -16,9 +16,12 @@ from .schema import ValidationError
 
 
 def parse_blueprints(value: str | None) -> list[str] | None:
-    if not value:
+    if value is None:
         return None
-    return [item.strip() for item in value.split(",") if item.strip()]
+    names = [item.strip() for item in value.split(",") if item.strip()]
+    if not names:
+        raise ValidationError("--blueprints must contain at least one blueprint name; omit it to select all")
+    return names
 
 
 def add_common_options(parser: argparse.ArgumentParser) -> None:
@@ -100,7 +103,7 @@ def main(argv: list[str] | None = None) -> int:
         else:
             project = Project(root)
             if command == "validate":
-                targets = [options.target] if options.target else ["preview", "prod"]
+                targets = [options.target] if options.target else project.target_names()
                 project.validate(targets=targets)
                 print(f"Validation passed for {len(project.all_blueprint_names())} blueprint(s).")
             elif command == "render":

--- a/src/md_blueprints/deploy.py
+++ b/src/md_blueprints/deploy.py
@@ -211,15 +211,17 @@ class Deployer:
         rendered = self._validate_and_render(target, branch, names)
         self._prepare_live_command(target, "cleanup")
         rendered_names = [blueprint.name for blueprint in rendered]
-        production = {
+        stable_target = self.project.preview_stable_target()
+        stable = {
             blueprint.name: blueprint
-            for blueprint in self.project.render_all("prod", names=rendered_names)
+            for blueprint in self.project.render_all(stable_target, names=rendered_names)
         }
         return self._build_cleanup_plan(
             rendered,
             branch_slug(branch or ""),
             branch=branch,
-            production=production,
+            production=stable,
+            stable_target=stable_target,
         )
 
     def cleanup(self, *, target: str, branch: str | None, names: list[str] | None) -> None:
@@ -241,12 +243,12 @@ class Deployer:
         names: list[str] | None,
     ) -> list[RenderedBlueprint]:
         self.project.validate(targets=[target], branch=branch)
-        expanded_names = self.project.deployment_blueprint_names(target, names)
+        expanded_names = set(self.project.deployment_blueprint_names(target, names))
         self.rendered_by_name = {
             blueprint.name: blueprint
             for blueprint in self.project.render_all(target, branch=branch)
         }
-        return self.project.render_all(target, branch=branch, names=expanded_names)
+        return [blueprint for name, blueprint in self.rendered_by_name.items() if name in expanded_names]
 
     def _prepare_live_command(self, target: str, operation: str) -> None:
         deployment = self.project.target_config(target).get("deployment", {})
@@ -456,6 +458,7 @@ class Deployer:
         *,
         branch: str | None = None,
         production: dict[str, RenderedBlueprint] | None = None,
+        stable_target: str = "prod",
     ) -> list[PlanRecord]:
         records: list[PlanRecord] = []
         dependency_safe = list(reversed(rendered))
@@ -472,7 +475,7 @@ class Deployer:
                     if raw_production_title is not None:
                         production_title = str(raw_production_title)
                 safety_error = self._preview_scope_error(
-                    "Guide", title, branch, rendered_branch_slug, production_title
+                    "Guide", title, branch, rendered_branch_slug, production_title, stable_target
                 )
                 if safety_error:
                     records.append(
@@ -497,7 +500,7 @@ class Deployer:
                 if production_blueprint and key in production_blueprint.dives:
                     production_title = str(production_blueprint.dives[key]["title"])
                 safety_error = self._preview_scope_error(
-                    "Dive", title, branch, rendered_branch_slug, production_title
+                    "Dive", title, branch, rendered_branch_slug, production_title, stable_target
                 )
                 if safety_error:
                     records.append(
@@ -519,7 +522,7 @@ class Deployer:
                 if production_blueprint and key in production_blueprint.flights:
                     production_name = str(production_blueprint.flights[key]["name"])
                 safety_error = self._preview_scope_error(
-                    "Flight", name, branch, rendered_branch_slug, production_name
+                    "Flight", name, branch, rendered_branch_slug, production_name, stable_target
                 )
                 if safety_error:
                     records.append(
@@ -544,7 +547,7 @@ class Deployer:
                 production_share = production_blueprint.shares.get(key) if production_blueprint else None
                 production_share_name = str(production_share["name"]) if production_share else None
                 share_safety_error = self._preview_scope_error(
-                    "share", share_name, branch, rendered_branch_slug, production_share_name
+                    "share", share_name, branch, rendered_branch_slug, production_share_name, stable_target
                 )
                 if share_safety_error:
                     records.append(
@@ -572,7 +575,7 @@ class Deployer:
 
                 production_database_name = str(production_share["database"]) if production_share else None
                 database_safety_error = self._preview_scope_error(
-                    "database", database_name, branch, rendered_branch_slug, production_database_name
+                    "database", database_name, branch, rendered_branch_slug, production_database_name, stable_target
                 )
                 if database_safety_error:
                     records.append(
@@ -610,9 +613,11 @@ class Deployer:
         branch: str | None,
         rendered_branch_slug: str,
         production_name: str | None,
+        stable_target: str = "prod",
     ) -> str | None:
         if production_name is not None and name == production_name:
-            return f"refusing to delete preview {resource_type} because it matches production: {name}"
+            stable_label = "production" if stable_target == "prod" else stable_target
+            return f"refusing to delete preview {resource_type} because it matches {stable_label}: {name}"
         branch_markers = {rendered_branch_slug}
         if branch:
             branch_markers.add(branch)

--- a/src/md_blueprints/maintenance.py
+++ b/src/md_blueprints/maintenance.py
@@ -87,14 +87,15 @@ def run_doctor(
     if not root_manifest.is_file():
         lines.append("project manifest: missing")
         emit_lines(lines, output_format=output_format)
-        return
+        raise ValidationError(f"motherduck.yml not found in {root}")
 
     try:
         project = Project(root)
+        project.validate()
     except (ValidationError, CommandError) as exc:
         lines.append(f"validation: failed ({exc})")
         emit_lines(lines, output_format=output_format)
-        return
+        raise
 
     root_version = project.manifest.get("schemaVersion")
     root_schema_version = root_version if isinstance(root_version, int) and not isinstance(root_version, bool) else -1
@@ -121,6 +122,26 @@ def run_doctor(
             "warning: resources.context is supported for compatibility; prefer resources.guides in: "
             + ", ".join(legacy_context_blueprints)
         )
+
+    for warning in project.deployment_warnings():
+        lines.append(f"warning: {warning}")
+
+    workflow = root / ".github" / "workflows" / "deploy_blueprints.yaml"
+    if workflow.is_file():
+        workflow_text = workflow.read_text(encoding="utf-8")
+        if "md-blueprints-environment-model: v1" not in workflow_text:
+            lines.append(
+                "warning: deploy workflow does not use target-declared GitHub Environments; the repository-level "
+                "MOTHERDUCK_TOKEN workflow is deprecated"
+            )
+        if project.has_target("staging") and 'target = "staging" if staging_enabled else "prod"' not in workflow_text:
+            lines.append(
+                "warning: staging is configured but the default-branch workflow does not select staging"
+            )
+        if project.has_target("staging") and "github.event_name == 'release'" not in workflow_text:
+            lines.append(
+                "warning: staging is configured but production is not deployed from a published GitHub Release"
+            )
 
     stale_schema = False
     unsupported = {root_schema_version, *blueprint_versions} - SUPPORTED_SCHEMA_VERSIONS

--- a/src/md_blueprints/migrations.py
+++ b/src/md_blueprints/migrations.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import yaml
 
+from .project import included_manifest_paths
 from .schema import LATEST_SCHEMA_VERSION, SUPPORTED_SCHEMA_VERSIONS, SchemaValidator, ValidationError, load_yaml
 
 Migration = Callable[[dict[str, object]], dict[str, object]]
@@ -14,16 +15,14 @@ MIGRATIONS: dict[tuple[int, int], Migration] = {}
 
 
 def project_manifest_files(root: Path) -> list[Path]:
+    root = root.expanduser().resolve()
     manifest_path = root / "motherduck.yml"
     manifest = load_yaml(manifest_path)
     if not isinstance(manifest, dict):
         raise ValidationError("motherduck.yml must be an object")
 
-    project_files = [manifest_path]
-    include = manifest.get("include", [])
-    for pattern in include if isinstance(include, list) else []:
-        project_files.extend(sorted(root.glob(str(pattern))))
-    return project_files
+    included = included_manifest_paths(root, manifest.get("include", []))
+    return [manifest_path, *(path for path in included if path != manifest_path)]
 
 
 def migration_path(source_version: int, target_version: int) -> list[Migration]:
@@ -68,8 +67,9 @@ def run_migrate(root: Path, *, from_version: int | None, to_version: str, write:
         if not isinstance(data, dict):
             raise ValidationError(f"{path} must be an object")
         version = data.get("schemaVersion")
-        if isinstance(version, int) and not isinstance(version, bool):
-            versions.add(version)
+        if not isinstance(version, int) or isinstance(version, bool):
+            raise ValidationError(f"{path}.schemaVersion must be an integer")
+        versions.add(version)
         documents.append((path, data))
 
     if from_version is not None and versions and versions != {from_version}:
@@ -97,6 +97,7 @@ def run_migrate(root: Path, *, from_version: int | None, to_version: str, write:
 
     validator = SchemaValidator()
     diffs: list[str] = []
+    updates: list[tuple[Path, str]] = []
     for path, data in documents:
         migrated = migrate_document(data, migrations)
         schema_name = "motherduck-root.schema.json" if path.name == "motherduck.yml" else "blueprint.schema.json"
@@ -107,13 +108,15 @@ def run_migrate(root: Path, *, from_version: int | None, to_version: str, write:
         updated = updated_text.splitlines(keepends=True)
         if original != updated:
             diffs.extend(difflib.unified_diff(original, updated, fromfile=str(path), tofile=str(path)))
-            if write:
-                path.write_text(updated_text, encoding="utf-8")
+            updates.append((path, updated_text))
 
     if not diffs:
         print("No migration changes were generated.")
         return
 
+    if write:
+        for path, updated_text in updates:
+            path.write_text(updated_text, encoding="utf-8")
     print("".join(diffs), end="")
     if write:
         print("Migration written.")

--- a/src/md_blueprints/project.py
+++ b/src/md_blueprints/project.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import ast
+import heapq
 import os
 import re
 import subprocess
-from collections import deque
+from collections import Counter, deque
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import cast
@@ -20,6 +21,20 @@ ROLE_MODES = {"additive", "authoritative"}
 
 class CommandError(Exception):
     pass
+
+
+def included_manifest_paths(root: Path, include: object) -> list[Path]:
+    if not isinstance(include, list):
+        raise ValidationError("$.include must be array")
+    paths: set[Path] = set()
+    for pattern in include:
+        if not isinstance(pattern, str):
+            raise ValidationError("Include patterns must be strings")
+        if Path(pattern).is_absolute() or ".." in Path(pattern).parts:
+            raise ValidationError(f"Include pattern must stay within the project root: {pattern}")
+        for path in root.glob(pattern):
+            paths.add(require_within(path, root, f"Included blueprint {path}"))
+    return sorted(paths)
 
 
 def branch_slug(branch: str) -> str:
@@ -121,11 +136,12 @@ class Project:
         self.schema.validate(self.manifest, "motherduck-root.schema.json")
         self.blueprints = self._load_blueprints()
         self._blueprints_by_name = {blueprint.name: blueprint for blueprint in self.blueprints}
+        self._validate_deployment_topology()
         self.dependencies, self.consumers = self._validate_contracts()
         self._topological_names = self._topological_sort()
 
     def validate(self, targets: list[str] | None = None, *, branch: str | None = None) -> bool:
-        target_names = targets or ["preview", "prod"]
+        target_names = targets or self.target_names()
         if not self.blueprints:
             raise ValidationError("No blueprints found from include globs")
 
@@ -138,7 +154,15 @@ class Project:
                 self._validate_rendered_blueprint(target, rendered_branch, blueprint)
             self._validate_guide_reference_targets(rendered)
             if target == "preview":
-                self._validate_preview_separation(rendered, self.render_all("prod"))
+                stable_target = self.preview_stable_target()
+                self._validate_preview_separation(
+                    rendered,
+                    self.render_all(stable_target),
+                    stable_target=stable_target,
+                )
+
+        if self.has_target("staging") and ({"staging", "prod"} & set(target_names)):
+            self._validate_staging_share_separation()
         return True
 
     def render_all(
@@ -162,6 +186,41 @@ class Project:
 
     def all_blueprint_names(self) -> list[str]:
         return list(self._topological_names)
+
+    def target_names(self) -> list[str]:
+        targets = self.manifest.get("targets")
+        if not isinstance(targets, dict):
+            return []
+        return [str(name) for name in targets]
+
+    def has_target(self, target: str) -> bool:
+        return target in self.target_names()
+
+    def preview_stable_target(self) -> str:
+        return "staging" if self.has_target("staging") else "prod"
+
+    def deployment_warnings(self) -> list[str]:
+        warnings: list[str] = []
+        for target in self.target_names():
+            config = self.target_config(target)
+            if not str(config.get("environment", "")).strip():
+                warnings.append(
+                    f"target {target!r} does not declare a GitHub Environment; repository-level deployment "
+                    "secrets are deprecated"
+                )
+            deployment = config.get("deployment")
+            identity = deployment.get("identity") if isinstance(deployment, dict) else None
+            if not str(identity or "").strip():
+                warnings.append(f"target {target!r} does not document deployment.identity")
+            if (
+                isinstance(deployment, dict)
+                and str(deployment.get("tokenEnvVar", "MOTHERDUCK_TOKEN")) != "MOTHERDUCK_TOKEN"
+            ):
+                warnings.append(
+                    f"target {target!r} uses deployment.tokenEnvVar other than MOTHERDUCK_TOKEN; generated "
+                    "GitHub Environment workflows require the canonical secret name"
+                )
+        return warnings
 
     def deployment_blueprint_names(self, target: str, names: list[str] | None) -> list[str]:
         """Expand an explicit deployment selection according to target graph semantics."""
@@ -229,19 +288,30 @@ class Project:
             return cast(dict[str, object], target_config)
         raise ValidationError(f"Unknown target {target}")
 
-    def _load_blueprints(self) -> list[Blueprint]:
-        include = self.manifest.get("include")
-        if not isinstance(include, list):
-            raise ValidationError("$.include must be array")
+    def _validate_deployment_topology(self) -> None:
+        if not self.has_target("preview") or not self.has_target("prod"):
+            return
+        preview_environment = str(self.target_config("preview").get("environment", "")).strip()
+        production_environment = str(self.target_config("prod").get("environment", "")).strip()
+        if self.has_target("staging"):
+            staging_environment = str(self.target_config("staging").get("environment", "")).strip()
+            if preview_environment and staging_environment and preview_environment != staging_environment:
+                raise ValidationError(
+                    "targets.preview.environment must match targets.staging.environment so previews use the "
+                    "staging service account"
+                )
+            if staging_environment and production_environment and staging_environment == production_environment:
+                raise ValidationError(
+                    "targets.staging.environment must differ from targets.prod.environment so production "
+                    "credentials are not exposed to staging jobs"
+                )
+        elif preview_environment and production_environment and preview_environment != production_environment:
+            raise ValidationError(
+                "without targets.staging, targets.preview.environment must match targets.prod.environment"
+            )
 
-        paths: set[Path] = set()
-        for pattern in include:
-            rendered_pattern = str(pattern)
-            pattern_path = Path(rendered_pattern)
-            if pattern_path.is_absolute() or ".." in pattern_path.parts:
-                raise ValidationError(f"Include pattern must stay within the project root: {rendered_pattern}")
-            for path in self.root.glob(rendered_pattern):
-                paths.add(require_within(path, self.root, f"Included blueprint {path}"))
+    def _load_blueprints(self) -> list[Blueprint]:
+        paths = included_manifest_paths(self.root, self.manifest.get("include"))
 
         blueprints: list[Blueprint] = []
         blueprint_paths: dict[str, Path] = {}
@@ -391,13 +461,12 @@ class Project:
         ready = sorted(name for name, count in indegree.items() if count == 0)
         ordered: list[str] = []
         while ready:
-            name = ready.pop(0)
+            name = heapq.heappop(ready)
             ordered.append(name)
             for consumer in sorted(self.consumers[name]):
                 indegree[consumer] -= 1
                 if indegree[consumer] == 0:
-                    ready.append(consumer)
-                    ready.sort()
+                    heapq.heappush(ready, consumer)
         if len(ordered) != len(self.blueprints):
             cycle = self._find_dependency_cycle()
             raise ValidationError(f"Blueprint dependency cycle: {' -> '.join(cycle)}")
@@ -497,7 +566,7 @@ class Project:
             role.setdefault("includedRoles", [])
             role.setdefault("members", [])
             role.setdefault("mode", "additive")
-            role["deploy"] = role.get("deploy", target == "prod")
+            role["deploy"] = role.get("deploy", target != "preview")
             if target == "preview":
                 role["deploy"] = False
         context_resources = context["resources"]
@@ -665,7 +734,7 @@ class Project:
             ],
         }
         for label, values in checks.items():
-            duplicates = sorted({str(value) for value in values if values.count(value) > 1})
+            duplicates = sorted(value for value, count in Counter(map(str, values)).items() if count > 1)
             if duplicates:
                 raise ValidationError(f"{label} duplicates in {target}: {', '.join(duplicates)}")
 
@@ -853,9 +922,12 @@ class Project:
     def _validate_preview_separation(
         self,
         preview_blueprints: list[RenderedBlueprint],
-        production_blueprints: list[RenderedBlueprint],
+        stable_blueprints: list[RenderedBlueprint],
+        *,
+        stable_target: str,
     ) -> None:
-        production = {blueprint.name: blueprint for blueprint in production_blueprints}
+        stable_label = "production" if stable_target == "prod" else stable_target
+        stable = {blueprint.name: blueprint for blueprint in stable_blueprints}
         resource_fields = [
             ("Flight", "flights", "name"),
             ("Dive", "dives", "title"),
@@ -863,33 +935,57 @@ class Project:
             ("database", "shares", "database"),
         ]
         for preview in preview_blueprints:
-            prod = production.get(preview.name)
-            if prod is None:
+            stable_blueprint = stable.get(preview.name)
+            if stable_blueprint is None:
                 continue
             for label, group_name, resource_field in resource_fields:
                 preview_group = cast(dict[str, dict[str, object]], getattr(preview, group_name))
-                production_group = cast(dict[str, dict[str, object]], getattr(prod, group_name))
+                stable_group = cast(dict[str, dict[str, object]], getattr(stable_blueprint, group_name))
                 for key, resource in preview_group.items():
-                    production_resource = production_group.get(key)
+                    stable_resource = stable_group.get(key)
                     if (
-                        production_resource is not None
-                        and resource.get(resource_field) == production_resource.get(resource_field)
+                        stable_resource is not None
+                        and resource.get(resource_field) == stable_resource.get(resource_field)
                     ):
                         raise ValidationError(
-                            f"preview {label} {preview.name}.{key} must not match its production {resource_field}: "
+                            f"preview {label} {preview.name}.{key} must not match its {stable_label} {resource_field}: "
                             f"{resource.get(resource_field)}"
                         )
             for key, guide in preview.guides.items():
-                production_guide = prod.guides.get(key)
+                stable_guide = stable_blueprint.guides.get(key)
                 if (
                     guide.get("deploy")
-                    and production_guide is not None
-                    and guide.get("title") == production_guide.get("title")
+                    and stable_guide is not None
+                    and guide.get("title") == stable_guide.get("title")
                 ):
                     raise ValidationError(
-                        f"preview Guide {preview.name}.{key} must not match its production title: "
+                        f"preview Guide {preview.name}.{key} must not match its {stable_label} title: "
                         f"{guide.get('title')}"
                     )
+
+    def _validate_staging_share_separation(self) -> None:
+        staging = self.render_all("staging")
+        production = self.render_all("prod")
+        staging_names = {
+            str(share["name"]): f"{blueprint.name}.{key}"
+            for blueprint in staging
+            for key, share in blueprint.shares.items()
+        }
+        production_names = {
+            str(share["name"]): f"{blueprint.name}.{key}"
+            for blueprint in production
+            for key, share in blueprint.shares.items()
+        }
+        duplicates = sorted(set(staging_names) & set(production_names))
+        if duplicates:
+            details = ", ".join(
+                f"{name!r} (staging {staging_names[name]}, prod {production_names[name]})"
+                for name in duplicates
+            )
+            raise ValidationError(
+                "staging and prod share names must differ because shares cannot be reused across deployment "
+                f"accounts: {details}"
+            )
 
     def _validate_grants(self, grants: object, label: str) -> None:
         if grants is None:

--- a/src/md_blueprints/scaffold.py
+++ b/src/md_blueprints/scaffold.py
@@ -5,6 +5,7 @@ import re
 from importlib import resources
 from pathlib import Path
 
+from .project import Project, require_within
 from .schema import ValidationError
 
 
@@ -65,6 +66,7 @@ def run_new(
         raise ValidationError(f"motherduck.yml not found in {root}")
 
     destination = root / KINDS[kind] / name
+    require_within(destination, root, "New blueprint destination")
     if destination.exists():
         raise ValidationError(f"Blueprint already exists: {destination.relative_to(root)}")
 
@@ -76,8 +78,6 @@ def run_new(
         raise ValidationError("--alias must not be empty")
     if share_url is not None:
         share_url = share_url.strip()
-
-    from .project import Project
 
     if name in Project(root).all_blueprint_names():
         raise ValidationError(f"Blueprint name already exists: {name}")
@@ -155,6 +155,8 @@ resources:
       cleanup: true
       dropDatabase: false
       targets:
+        staging:
+          name: ${{var.share}}_staging
         preview:
           name: ${{var.share}}${{var.preview_suffix}}
           database: ${{var.database}}${{var.preview_suffix}}
@@ -251,8 +253,6 @@ def _required_database(
 
     assert input_ref is not None
     producer, output = _parse_input_ref(input_ref)
-
-    from .project import Project
 
     project = Project(root)
     if producer not in project.all_blueprint_names():

--- a/src/md_blueprints/schemas/v1/motherduck-root.schema.json
+++ b/src/md_blueprints/schemas/v1/motherduck-root.schema.json
@@ -29,6 +29,7 @@
       "additionalProperties": { "$ref": "#/$defs/target" },
       "properties": {
         "preview": { "$ref": "#/$defs/target" },
+        "staging": { "$ref": "#/$defs/target" },
         "prod": { "$ref": "#/$defs/target" }
       }
     }
@@ -57,7 +58,7 @@
       "properties": {
         "mode": { "type": "string", "minLength": 1 },
         "default": { "type": "boolean" },
-        "environment": { "type": "string" },
+        "environment": { "type": "string", "minLength": 1 },
         "deployment": {
           "type": "object",
           "additionalProperties": false,

--- a/src/md_blueprints/template_repo/.dive-preview/package-lock.json
+++ b/src/md_blueprints/template_repo/.dive-preview/package-lock.json
@@ -1253,9 +1253,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/src/md_blueprints/template_repo/.github/pull_request_template.md
+++ b/src/md_blueprints/template_repo/.github/pull_request_template.md
@@ -1,20 +1,9 @@
 ## What changed?
 
-- [ ] Dives
-- [ ] Flights
-- [ ] Shares
-- [ ] Context layer
-- [ ] CI or scripts
-- [ ] Docs only
+Describe the change and why it is needed.
 
-## Deployment notes
+## Before merging
 
-- [ ] New or renamed assets are declared in a typed-root or `projects/<name>/blueprint.yml` package.
-- [ ] Dives list required resources in `blueprint.yml`.
-- [ ] Dive statuses are intentional: previews are `draft`, and `endorsed` production changes have an organization-admin reviewer.
-- [ ] Preview shares/databases that can be cleaned up include `${target.branch_slug}`.
-- [ ] Blueprints validate with `make validate`.
-- [ ] Dives build with `make preview-smoke <blueprint-name>` when changed.
-- [ ] Package/action/schema docs are updated when tooling behavior changed.
-- [ ] Docs are updated when layout, commands, target behavior, or resource semantics changed.
-- [ ] Production deploy has an owner/reviewer.
+- [ ] Validation passed.
+- [ ] I checked the preview and deployment plan, if this PR changes deployed resources.
+- [ ] I noted any production data or permission changes below.

--- a/src/md_blueprints/template_repo/.github/workflows/cleanup_preview_blueprints.yaml
+++ b/src/md_blueprints/template_repo/.github/workflows/cleanup_preview_blueprints.yaml
@@ -1,3 +1,4 @@
+# md-blueprints-environment-model: v1
 name: Cleanup Preview Blueprints
 
 permissions:
@@ -14,10 +15,66 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  resolve-environment:
+    name: Resolve Preview Environment
+    if: >-
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'delete' && github.event.ref_type == 'branch')
+    runs-on: ubuntu-latest
+    outputs:
+      environment: ${{ steps.preview-target.outputs.environment }}
+      identity: ${{ steps.preview-target.outputs.identity }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
+
+      - name: Validate base deployment configuration
+        uses: motherduckdb/motherduck-blueprints@__MD_BLUEPRINTS_ACTION_TAG__
+        with:
+          command: validate
+
+      - name: Resolve preview target
+        id: preview-target
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import os
+          from pathlib import Path
+
+          import yaml
+
+          manifest = yaml.safe_load(Path("motherduck.yml").read_text(encoding="utf-8"))
+          preview = manifest.get("targets", {}).get("preview", {})
+          environment = str(preview.get("environment", "")).strip()
+          deployment = preview.get("deployment", {})
+          identity = str(deployment.get("identity", "")).strip() if isinstance(deployment, dict) else ""
+          token_env_var = (
+              str(deployment.get("tokenEnvVar", "MOTHERDUCK_TOKEN")).strip()
+              if isinstance(deployment, dict)
+              else ""
+          )
+          if not environment or not identity:
+              raise SystemExit(
+                  "Target 'preview' must declare environment and deployment.identity before preview cleanup"
+              )
+          if token_env_var != "MOTHERDUCK_TOKEN":
+              raise SystemExit(
+                  "Target 'preview' must use deployment.tokenEnvVar: MOTHERDUCK_TOKEN with the generated "
+                  "GitHub Environment workflow"
+              )
+          output = Path(os.environ["GITHUB_OUTPUT"])
+          with output.open("a", encoding="utf-8") as handle:
+              handle.write(f"environment={environment}\n")
+              handle.write(f"identity={identity}\n")
+          PY
+
   cleanup:
     name: Delete Preview Blueprints for Branch
-    if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'delete' && github.event.ref_type == 'branch')
+    needs: resolve-environment
     runs-on: ubuntu-latest
+    environment: ${{ needs.resolve-environment.outputs.environment }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -33,56 +90,53 @@ jobs:
           set -euo pipefail
           branch_name="${PR_BRANCH:-$DELETED_BRANCH}"
           if [ -z "$branch_name" ]; then
-            echo "No branch name available for cleanup"
-            echo "available=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=true" >> "$GITHUB_OUTPUT"
-            echo "branch=${branch_name}" >> "$GITHUB_OUTPUT"
+            echo "No branch name available for cleanup" >&2
+            exit 1
           fi
+          echo "branch=${branch_name}" >> "$GITHUB_OUTPUT"
 
-      - name: Check cleanup token
-        id: cleanup-token
-        if: steps.cleanup-branch.outputs.available == 'true'
+      - name: Require preview environment token
         shell: bash
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          TARGET_ENVIRONMENT: ${{ needs.resolve-environment.outputs.environment }}
+          TARGET_IDENTITY: ${{ needs.resolve-environment.outputs.identity }}
         run: |
           set -euo pipefail
           if [ -z "$MOTHERDUCK_TOKEN" ]; then
-            echo "Preview cleanup skipped because MOTHERDUCK_TOKEN is not configured for this repository."
-            echo "available=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "Target preview expects GitHub Environment '$TARGET_ENVIRONMENT' to contain a MOTHERDUCK_TOKEN secret for $TARGET_IDENTITY." >&2
+            exit 1
           fi
 
       - name: Cleanup preview blueprints from the branch manifest
         id: cleanup-branch-manifest
-        if: steps.cleanup-token.outputs.available == 'true'
         continue-on-error: ${{ github.event_name == 'pull_request' }}
         uses: motherduckdb/motherduck-blueprints@__MD_BLUEPRINTS_ACTION_TAG__
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         with:
           command: cleanup
-          args: --target preview --branch "${{ steps.cleanup-branch.outputs.branch }}"
+          target: preview
+          branch: ${{ steps.cleanup-branch.outputs.branch }}
 
       - name: Check out the pull request base manifest
-        if: github.event_name == 'pull_request' && steps.cleanup-token.outputs.available == 'true'
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Cleanup preview blueprints from the base manifest
-        if: github.event_name == 'pull_request' && steps.cleanup-token.outputs.available == 'true'
+        if: ${{ github.event_name == 'pull_request' }}
         uses: motherduckdb/motherduck-blueprints@__MD_BLUEPRINTS_ACTION_TAG__
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         with:
           command: cleanup
-          args: --target preview --branch "${{ steps.cleanup-branch.outputs.branch }}"
+          target: preview
+          branch: ${{ steps.cleanup-branch.outputs.branch }}
 
       - name: Report branch-manifest cleanup failure
-        if: always() && steps.cleanup-branch-manifest.outcome == 'failure'
+        if: ${{ always() && steps.cleanup-branch-manifest.outcome == 'failure' }}
         shell: bash
         run: |
           echo "Cleanup using the pull request branch manifest failed; the base manifest cleanup was still attempted." >&2

--- a/src/md_blueprints/template_repo/.github/workflows/deploy_blueprints.yaml
+++ b/src/md_blueprints/template_repo/.github/workflows/deploy_blueprints.yaml
@@ -167,11 +167,11 @@ jobs:
               if isinstance(deployment, dict)
               else ""
           )
-          if not environment or not identity:
+          if deployment_enabled and (not environment or not identity):
               raise SystemExit(
                   f"Target {target!r} must declare environment and deployment.identity before live CI deployment"
               )
-          if token_env_var != "MOTHERDUCK_TOKEN":
+          if deployment_enabled and token_env_var != "MOTHERDUCK_TOKEN":
               raise SystemExit(
                   f"Target {target!r} must use deployment.tokenEnvVar: MOTHERDUCK_TOKEN with the generated "
                   "GitHub Environment workflow"

--- a/src/md_blueprints/template_repo/.github/workflows/deploy_blueprints.yaml
+++ b/src/md_blueprints/template_repo/.github/workflows/deploy_blueprints.yaml
@@ -1,12 +1,9 @@
+# md-blueprints-environment-model: v1
 name: Deploy Blueprints
 
 permissions:
   contents: read
   pull-requests: write
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
   workflow_dispatch:
@@ -18,6 +15,7 @@ on:
         type: choice
         options:
           - preview
+          - staging
           - prod
       branch:
         description: Preview branch name for manual preview deploys.
@@ -39,7 +37,12 @@ on:
       - "roles/**"
       - "projects/**"
       - "schemas/**"
+      - "src/**"
+      - "tools/**"
+      - "scripts/**"
       - "templates/**"
+      - "action.yml"
+      - "pyproject.toml"
       - ".github/workflows/deploy_blueprints.yaml"
   pull_request:
     branches:
@@ -53,24 +56,139 @@ on:
       - "roles/**"
       - "projects/**"
       - "schemas/**"
+      - "src/**"
+      - "tools/**"
+      - "scripts/**"
       - "templates/**"
+      - "action.yml"
+      - "pyproject.toml"
       - ".github/workflows/deploy_blueprints.yaml"
+  release:
+    types:
+      - published
 
 jobs:
   compute_changes:
-    name: Identify Changed Blueprints
+    name: Validate and Identify Deployment
     runs-on: ubuntu-latest
     outputs:
       changed_blueprints: ${{ steps.changed.outputs.changed_blueprints }}
       changed_csv: ${{ steps.changed.outputs.changed_csv }}
+      target: ${{ steps.topology.outputs.target }}
+      target_environment: ${{ steps.topology.outputs.environment }}
+      target_identity: ${{ steps.topology.outputs.identity }}
+      staging_enabled: ${{ steps.topology.outputs.staging_enabled }}
+      deployment_enabled: ${{ steps.topology.outputs.deployment_enabled }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
+
+      - name: Validate configured targets
+        uses: motherduckdb/motherduck-blueprints@__MD_BLUEPRINTS_ACTION_TAG__
+        with:
+          command: validate
+
+      - name: Resolve deployment topology
+        id: topology
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TARGET: ${{ inputs.target }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import os
+          import subprocess
+          from pathlib import Path
+
+          import yaml
+
+          manifest = yaml.safe_load(Path("motherduck.yml").read_text(encoding="utf-8"))
+          targets = manifest.get("targets", {})
+          staging_enabled = "staging" in targets
+          event_name = os.environ["EVENT_NAME"]
+          deployment_enabled = True
+
+          if event_name == "pull_request":
+              target = "preview"
+          elif event_name == "push":
+              target = "staging" if staging_enabled else "prod"
+          elif event_name == "release":
+              target = "prod"
+              deployment_enabled = staging_enabled and os.environ.get("RELEASE_PRERELEASE", "false") != "true"
+          elif event_name == "workflow_dispatch":
+              target = os.environ.get("INPUT_TARGET", "prod") or "prod"
+          else:
+              raise SystemExit(f"Unsupported deployment event: {event_name}")
+
+          if target not in targets:
+              raise SystemExit(
+                  f"Target {target!r} is not declared in motherduck.yml. "
+                  "Add targets.staging before dispatching a staging deployment."
+              )
+
+          config = targets[target]
+          if event_name == "pull_request":
+              base_ref = os.environ.get("BASE_REF", "")
+              base_text = subprocess.check_output(
+                  ["git", "show", f"origin/{base_ref}:motherduck.yml"],
+                  text=True,
+              )
+              base_manifest = yaml.safe_load(base_text)
+              base_config = base_manifest.get("targets", {}).get("preview", {})
+              branch_deployment = config.get("deployment", {})
+              base_deployment = base_config.get("deployment", {})
+              branch_identity = (
+                  str(branch_deployment.get("identity", "")).strip()
+                  if isinstance(branch_deployment, dict)
+                  else ""
+              )
+              base_identity = (
+                  str(base_deployment.get("identity", "")).strip()
+                  if isinstance(base_deployment, dict)
+                  else ""
+              )
+              if (
+                  str(config.get("environment", "")).strip()
+                  != str(base_config.get("environment", "")).strip()
+                  or branch_identity != base_identity
+              ):
+                  deployment_enabled = False
+              config = base_config
+          environment = str(config.get("environment", "")).strip()
+          deployment = config.get("deployment", {})
+          identity = str(deployment.get("identity", "")).strip() if isinstance(deployment, dict) else ""
+          token_env_var = (
+              str(deployment.get("tokenEnvVar", "MOTHERDUCK_TOKEN")).strip()
+              if isinstance(deployment, dict)
+              else ""
+          )
+          if not environment or not identity:
+              raise SystemExit(
+                  f"Target {target!r} must declare environment and deployment.identity before live CI deployment"
+              )
+          if token_env_var != "MOTHERDUCK_TOKEN":
+              raise SystemExit(
+                  f"Target {target!r} must use deployment.tokenEnvVar: MOTHERDUCK_TOKEN with the generated "
+                  "GitHub Environment workflow"
+              )
+
+          output = Path(os.environ["GITHUB_OUTPUT"])
+          with output.open("a", encoding="utf-8") as handle:
+              handle.write(f"target={target}\n")
+              handle.write(f"environment={environment}\n")
+              handle.write(f"identity={identity}\n")
+              handle.write(f"staging_enabled={str(staging_enabled).lower()}\n")
+              handle.write(f"deployment_enabled={str(deployment_enabled).lower()}\n")
+          PY
 
       - name: Use manually selected blueprints
         id: manual-changed
-        if: ${{ inputs.blueprints != '' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.blueprints != '' }}
         shell: bash
         env:
           INPUT_BLUEPRINTS: ${{ inputs.blueprints }}
@@ -81,7 +199,7 @@ jobs:
 
       - name: Compute changed blueprints for pull request
         id: changed-pr
-        if: ${{ inputs.blueprints == '' && github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' }}
         uses: motherduckdb/motherduck-blueprints@__MD_BLUEPRINTS_ACTION_TAG__
         with:
           command: changed
@@ -89,7 +207,7 @@ jobs:
 
       - name: Resolve push comparison range
         id: push-range
-        if: ${{ inputs.blueprints == '' && github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' }}
         shell: bash
         env:
           PUSH_BEFORE: ${{ github.event.before }}
@@ -103,15 +221,15 @@ jobs:
 
       - name: Compute changed blueprints for push
         id: changed-push
-        if: ${{ inputs.blueprints == '' && github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' }}
         uses: motherduckdb/motherduck-blueprints@__MD_BLUEPRINTS_ACTION_TAG__
         with:
           command: changed
           args: ${{ steps.push-range.outputs.args }}
 
-      - name: Select all blueprints for manual dispatch
+      - name: Select all blueprints
         id: changed-all
-        if: ${{ inputs.blueprints == '' && github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.blueprints == '') }}
         uses: motherduckdb/motherduck-blueprints@__MD_BLUEPRINTS_ACTION_TAG__
         with:
           command: changed
@@ -133,25 +251,19 @@ jobs:
           echo "changed_blueprints=${changed}" >> "$GITHUB_OUTPUT"
           echo "changed_csv=${csv}" >> "$GITHUB_OUTPUT"
 
-  validate:
-    name: Validate Blueprints
-    needs: compute_changes
-    if: needs.compute_changes.outputs.changed_blueprints != '[]'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - uses: motherduckdb/motherduck-blueprints@__MD_BLUEPRINTS_ACTION_TAG__
-        with:
-          command: validate
-
   deploy-preview:
     name: Deploy Preview Blueprints
-    needs:
-      - compute_changes
-      - validate
-    if: needs.compute_changes.outputs.changed_blueprints != '[]' && (github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.target == 'preview'))
+    needs: compute_changes
+    if: >-
+      needs.compute_changes.outputs.changed_blueprints != '[]' &&
+      needs.compute_changes.outputs.target == 'preview' &&
+      needs.compute_changes.outputs.deployment_enabled == 'true' &&
+      (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
+    environment: ${{ needs.compute_changes.outputs.target_environment }}
+    concurrency:
+      group: preview-${{ github.event.pull_request.number || inputs.branch }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -168,82 +280,58 @@ jobs:
           fi
           echo "branch=${PREVIEW_BRANCH}" >> "$GITHUB_OUTPUT"
 
-      - name: Check preview token
-        id: preview-token
+      - name: Require preview environment token
         shell: bash
         env:
-          EVENT_NAME: ${{ github.event_name }}
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          TARGET_ENVIRONMENT: ${{ needs.compute_changes.outputs.target_environment }}
+          TARGET_IDENTITY: ${{ needs.compute_changes.outputs.target_identity }}
         run: |
           set -euo pipefail
-          if [ -n "$MOTHERDUCK_TOKEN" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          elif [ "$EVENT_NAME" = "pull_request" ]; then
-            echo "available=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "MOTHERDUCK_TOKEN is required for preview deploys" >&2
+          if [ -z "$MOTHERDUCK_TOKEN" ]; then
+            echo "Target preview expects GitHub Environment '$TARGET_ENVIRONMENT' to contain a MOTHERDUCK_TOKEN secret for $TARGET_IDENTITY." >&2
             exit 1
           fi
 
       - name: Plan preview blueprints
         id: plan-preview
-        if: steps.preview-token.outputs.available == 'true'
         uses: motherduckdb/motherduck-blueprints@__MD_BLUEPRINTS_ACTION_TAG__
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         with:
           command: plan
-          args: --target preview --branch "${{ steps.preview-branch.outputs.branch }}" --blueprints "${{ needs.compute_changes.outputs.changed_csv }}"
+          target: preview
+          branch: ${{ steps.preview-branch.outputs.branch }}
+          blueprints: ${{ needs.compute_changes.outputs.changed_csv }}
 
       - name: Deploy preview blueprints
         id: deploy-preview
-        if: steps.preview-token.outputs.available == 'true'
         uses: motherduckdb/motherduck-blueprints@__MD_BLUEPRINTS_ACTION_TAG__
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         with:
           command: deploy
-          args: --target preview --branch "${{ steps.preview-branch.outputs.branch }}" --blueprints "${{ needs.compute_changes.outputs.changed_csv }}"
+          target: preview
+          branch: ${{ steps.preview-branch.outputs.branch }}
+          blueprints: ${{ needs.compute_changes.outputs.changed_csv }}
 
-      - name: Build preview comment body
-        id: preview-comment
-        shell: bash
-        env:
-          TOKEN_AVAILABLE: ${{ steps.preview-token.outputs.available }}
-          PLAN_OUTPUT: ${{ steps.plan-preview.outputs.stdout }}
-          DEPLOY_OUTPUT: ${{ steps.deploy-preview.outputs.stdout }}
-        run: |
-          set -euo pipefail
-          if [ "$TOKEN_AVAILABLE" = "true" ]; then
-            output="$(printf "%s\n\n%s" "$PLAN_OUTPUT" "$DEPLOY_OUTPUT")"
-          else
-            output="Preview deploy skipped because MOTHERDUCK_TOKEN is not configured for this repository."
-          fi
-          {
-            echo "comment_body<<EOF"
-            printf "%s\n" "$output"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Comment on PR
-        if: github.event_name == 'pull_request' && steps.preview-comment.outputs.comment_body != ''
+      - name: Comment on pull request
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          COMMENT_BODY: ${{ steps.preview-comment.outputs.comment_body }}
+          PLAN_OUTPUT: ${{ steps.plan-preview.outputs.stdout }}
+          DEPLOY_OUTPUT: ${{ steps.deploy-preview.outputs.stdout }}
         with:
           script: |
             const marker = '<!-- preview-blueprints-comment -->';
-            const body = `${marker}
-            ### Preview Blueprints
-
-            ${process.env.COMMENT_BODY ?? ''}`.replace(/^ +/gm, '');
-
+            const output = `${process.env.PLAN_OUTPUT ?? ''}\n\n${process.env.DEPLOY_OUTPUT ?? ''}`;
+            const body = `${marker}\n### Preview Blueprints\n\n${output}`;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
             });
-            const existing = comments.find(c => c.body.includes(marker));
+            const existing = comments.find(comment => comment.body.includes(marker));
             if (existing) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,
@@ -260,58 +348,138 @@ jobs:
               });
             }
 
-  deploy-prod:
-    name: Deploy Production Blueprints
-    needs:
-      - compute_changes
-      - validate
-    if: needs.compute_changes.outputs.changed_blueprints != '[]' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.target == 'prod'))
+  deploy-stable:
+    name: Deploy ${{ needs.compute_changes.outputs.target }} Blueprints
+    needs: compute_changes
+    if: >-
+      needs.compute_changes.outputs.changed_blueprints != '[]' &&
+      needs.compute_changes.outputs.target != 'preview' &&
+      github.event_name != 'release'
     runs-on: ubuntu-latest
-    environment: motherduck-production
+    environment: ${{ needs.compute_changes.outputs.target_environment }}
+    concurrency:
+      group: stable-${{ needs.compute_changes.outputs.target }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Check production token
-        id: prod-token
+      - name: Require target environment token
         shell: bash
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          TARGET: ${{ needs.compute_changes.outputs.target }}
+          TARGET_ENVIRONMENT: ${{ needs.compute_changes.outputs.target_environment }}
+          TARGET_IDENTITY: ${{ needs.compute_changes.outputs.target_identity }}
         run: |
           set -euo pipefail
-          if [ -n "$MOTHERDUCK_TOKEN" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "Production deploy skipped because MOTHERDUCK_TOKEN is not configured for this repository."
+          if [ -z "$MOTHERDUCK_TOKEN" ]; then
+            echo "Target $TARGET expects GitHub Environment '$TARGET_ENVIRONMENT' to contain a MOTHERDUCK_TOKEN secret for $TARGET_IDENTITY." >&2
+            exit 1
           fi
 
-      - name: Plan production blueprints
-        id: plan-prod
-        if: steps.prod-token.outputs.available == 'true'
+      - name: Plan target blueprints
+        id: plan-stable
         uses: motherduckdb/motherduck-blueprints@__MD_BLUEPRINTS_ACTION_TAG__
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         with:
           command: plan
-          args: --target prod --blueprints "${{ needs.compute_changes.outputs.changed_csv }}"
+          target: ${{ needs.compute_changes.outputs.target }}
+          blueprints: ${{ needs.compute_changes.outputs.changed_csv }}
 
-      - name: Summarize production plan
-        if: steps.prod-token.outputs.available == 'true'
+      - name: Summarize deployment plan
         shell: bash
         env:
-          PLAN_OUTPUT: ${{ steps.plan-prod.outputs.stdout }}
+          PLAN_OUTPUT: ${{ steps.plan-stable.outputs.stdout }}
+          TARGET: ${{ needs.compute_changes.outputs.target }}
         run: |
           {
-            echo "### Production Blueprint Plan"
+            echo "### ${TARGET} Blueprint Plan"
             echo
             printf "%s\n" "$PLAN_OUTPUT"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Deploy production blueprints
-        if: steps.prod-token.outputs.available == 'true'
+      - name: Deploy target blueprints
         uses: motherduckdb/motherduck-blueprints@__MD_BLUEPRINTS_ACTION_TAG__
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         with:
           command: deploy
-          args: --target prod --blueprints "${{ needs.compute_changes.outputs.changed_csv }}"
+          target: ${{ needs.compute_changes.outputs.target }}
+          blueprints: ${{ needs.compute_changes.outputs.changed_csv }}
+
+  deploy-release-production:
+    name: Deploy Released Production Blueprints
+    needs: compute_changes
+    if: >-
+      github.event_name == 'release' &&
+      needs.compute_changes.outputs.staging_enabled == 'true' &&
+      needs.compute_changes.outputs.deployment_enabled == 'true'
+    runs-on: ubuntu-latest
+    environment: ${{ needs.compute_changes.outputs.target_environment }}
+    concurrency:
+      group: stable-prod
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Verify released commit belongs to the default branch
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "$DEFAULT_BRANCH"
+          release_commit="$(git rev-list -n 1 "$RELEASE_TAG")"
+          git merge-base --is-ancestor "$release_commit" "origin/$DEFAULT_BRANCH" || {
+            echo "Release tag $RELEASE_TAG does not point to a commit on $DEFAULT_BRANCH." >&2
+            exit 1
+          }
+
+      - name: Require production environment token
+        shell: bash
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          TARGET_ENVIRONMENT: ${{ needs.compute_changes.outputs.target_environment }}
+          TARGET_IDENTITY: ${{ needs.compute_changes.outputs.target_identity }}
+        run: |
+          set -euo pipefail
+          if [ -z "$MOTHERDUCK_TOKEN" ]; then
+            echo "Target prod expects GitHub Environment '$TARGET_ENVIRONMENT' to contain a MOTHERDUCK_TOKEN secret for $TARGET_IDENTITY." >&2
+            exit 1
+          fi
+
+      - name: Plan released production blueprints
+        id: plan-production
+        uses: motherduckdb/motherduck-blueprints@__MD_BLUEPRINTS_ACTION_TAG__
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        with:
+          command: plan
+          target: prod
+          blueprints: ${{ needs.compute_changes.outputs.changed_csv }}
+
+      - name: Summarize production plan
+        shell: bash
+        env:
+          PLAN_OUTPUT: ${{ steps.plan-production.outputs.stdout }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          {
+            echo "### Production Blueprint Plan for ${RELEASE_TAG}"
+            echo
+            printf "%s\n" "$PLAN_OUTPUT"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Deploy released production blueprints
+        uses: motherduckdb/motherduck-blueprints@__MD_BLUEPRINTS_ACTION_TAG__
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        with:
+          command: deploy
+          target: prod
+          blueprints: ${{ needs.compute_changes.outputs.changed_csv }}

--- a/src/md_blueprints/template_repo/Makefile
+++ b/src/md_blueprints/template_repo/Makefile
@@ -4,12 +4,13 @@ ARG := $(word 2,$(MAKECMDGOALS))
 CLI_VERSION := __MD_BLUEPRINTS_VERSION__
 CLI := .venv/bin/md-blueprints
 CLI_SOURCE := git+https://github.com/motherduckdb/motherduck-blueprints.git@v$(CLI_VERSION)
+PYTHON ?= python3
 
 .PHONY: cli
 cli:
 	@installed_version="$$( [ -x "$(CLI)" ] && "$(CLI)" --version 2>/dev/null || true )"; \
 	  if [ "$$installed_version" != "$(CLI_VERSION)" ]; then \
-	    python3 -m venv .venv; \
+	    { test -x .venv/bin/python || $(PYTHON) -m venv .venv; } && \
 	    .venv/bin/python -m pip install "md-blueprints @ $(CLI_SOURCE)"; \
 	  fi
 
@@ -28,16 +29,16 @@ install-deploy: $(CLI) ## Install CLI with live MotherDuck deploy dependencies
 	.venv/bin/python -m pip install "md-blueprints[deploy] @ $(CLI_SOURCE)"
 
 .PHONY: preview
-preview: ## Preview a blueprint Dive locally (e.g. make preview wikipedia-pageviews)
+preview: $(CLI) ## Preview a blueprint Dive locally (e.g. make preview wikipedia-pageviews)
 	@test -n "$(ARG)" || { echo "Usage: make preview <blueprint-name>"; exit 1; }
-	@SOURCE="$$( $(CLI) dive-source --blueprints "$(ARG)" $(if $(DIVE),--dive "$(DIVE)") )"; \
+	@SOURCE="$$( $(CLI) dive-source --blueprints "$(ARG)" $(if $(DIVE),--dive "$(DIVE)") )" && \
 	  echo "export { default, REQUIRED_DATABASES } from \"../../$${SOURCE%.tsx}\";" > .dive-preview/src/dive.tsx
 	cd .dive-preview && npm run dev
 
 .PHONY: preview-smoke
-preview-smoke: ## Build a blueprint Dive preview without starting a dev server
+preview-smoke: $(CLI) ## Build a blueprint Dive preview without starting a dev server
 	@test -n "$(ARG)" || { echo "Usage: make preview-smoke <blueprint-name>"; exit 1; }
-	@SOURCE="$$( $(CLI) dive-source --blueprints "$(ARG)" $(if $(DIVE),--dive "$(DIVE)") )"; \
+	@SOURCE="$$( $(CLI) dive-source --blueprints "$(ARG)" $(if $(DIVE),--dive "$(DIVE)") )" && \
 	  echo "export { default, REQUIRED_DATABASES } from \"../../$${SOURCE%.tsx}\";" > .dive-preview/src/dive.tsx
 	cd .dive-preview && { test -x node_modules/.bin/vite || npm install; }
 	cd .dive-preview && npm run build

--- a/src/md_blueprints/template_repo/README.md
+++ b/src/md_blueprints/template_repo/README.md
@@ -1,112 +1,60 @@
-# MotherDuck Blueprints
+# Your MotherDuck project
 
-This repository deploys MotherDuck [Flights](https://motherduck.com/docs/concepts/flights/), [Dives](https://motherduck.com/docs/key-tasks/ai-and-motherduck/dives/), shares, Guides, and RBAC roles from GitHub. Typed roots make ownership visible, while explicit inputs and outputs connect independently deployed packages. Pull requests deploy branch-scoped dependency graphs; merges deploy stable production resources through the protected `motherduck-production` environment.
+This repository uses MotherDuck Blueprints to deploy your data pipelines and dashboards.
 
-Dive previews are always `draft`. Production blueprints can declare `ready`, `endorsed`, or `archived`, and deployment plans show status transitions before applying them. Omitting status preserves the current live value.
+**Open a pull request → try a preview → merge to deploy production.**
 
-If you are reading this in `motherduckdb/blueprints-template`, do not open pull requests there. That repository is generated from `motherduckdb/motherduck-blueprints` on each release, and direct edits are overwritten.
+If you are viewing the original template, [create your own repository first](https://github.com/motherduckdb/blueprints-template/generate).
 
-## Prerequisites
+## Deploy the example
 
-- Python 3.10 or newer.
-- Git, used to install the versioned CLI source locally.
-- Node.js 20 or newer (only needed to preview Dives locally).
-- GitHub Actions secrets and a protected `motherduck-production` environment.
-- A MotherDuck [service account](https://motherduck.com/docs/key-tasks/service-accounts-guide/) token for CI deployments.
+You need a MotherDuck service-account token and permission to configure your GitHub repository. No local installation is required.
 
-## Quickstart
+1. In GitHub, open **Settings → Environments**, create `motherduck-production`, and add your token as an environment secret named `MOTHERDUCK_TOKEN`.
+2. Open [`flights/wikipedia-pageviews-ingest/blueprint.yml`](flights/wikipedia-pageviews-ingest/blueprint.yml), change its `description`, and commit the change to a **new branch**. Open a pull request.
+3. Wait for **Deploy Blueprints** to finish. Its PR comment links to your preview dashboard, backed by public Wikipedia pageview data.
+4. Merge the PR to deploy production. Closing the PR removes its preview resources.
 
-Start without touching MotherDuck:
+If the environment requires approval, approve the deployment in GitHub Actions. Fork pull requests validate but do not deploy.
+
+The default setup uses the same service account for previews and production. For separate credentials and release-based production deployment, [add staging](docs/setup-your-repository.md#add-staging-optional).
+
+## Make it yours
+
+Each `blueprint.yml` describes what to deploy; the source files beside it contain your code. Start by editing the Wikipedia example:
+
+- [Flight](flights/wikipedia-pageviews-ingest/): Python that loads data and publishes a share.
+- [Dive](dives/wikipedia-pageviews/): the dashboard that reads that share.
+
+The repository also includes an [NCS field recovery example](projects/ncs-field-recovery/README.md). All included examples can deploy; remove unwanted example packages before your first deployment.
+
+For local checks, install Python 3.10+ and Git, then run:
+
+```bash
+make validate
+```
+
+To build the example dashboard locally, also install Node.js 22+:
 
 ```bash
 make setup
-make validate
 make preview-smoke wikipedia-pageviews
 ```
 
-Then connect MotherDuck:
+These checks do not need a MotherDuck token. A preview build checks the dashboard; it does not open a live preview.
 
-1. Add a GitHub Actions secret named `MOTHERDUCK_TOKEN`.
-2. Create a GitHub Environment named `motherduck-production`.
-3. Open a small pull request and confirm the preview deployment comment appears.
-4. Merge after review to deploy production through the protected environment.
-
-See [Set Up Your Repository](docs/setup-your-repository.md) for the full setup flow and [GitHub Setup](docs/github-setup.md) for the GitHub checklist.
-
-## Add a Blueprint
-
-A blueprint is an independently deployable package. Use the root matching its ownership boundary:
-
-```text
-flights/   # producers, shares, and named outputs
-dives/     # dashboards with declared inputs
-guides/    # version-controlled agent context
-roles/     # production RBAC roles and memberships
-projects/  # resources that genuinely ship together
-shared/    # human convention; no deployment behavior
-```
-
-Create a producer and consumer:
+Create your own data pipeline and dashboard with:
 
 ```bash
-make new-flight events-ingest
-make new-dive events-dashboard INPUT=events-ingest.data
-make validate
-make preview-smoke events-dashboard
-```
-
-Use `make new-project revenue-overview` when several resources genuinely ship together. `make new-blueprint` remains a compatibility alias, and existing `blueprints/<name>/` packages continue to work.
-
-Guide packages can publish versioned Markdown with catalog and resource references. Role packages and share grants provide declarative RBAC; admin-only operations run a capability preflight before mutation.
-
-Create a Guide package and validate it without publishing:
-
-```bash
-make new-guide revenue-metrics
+make new-project revenue
 make validate
 ```
 
-When the content is ready, follow [Manage Guides as code](docs/guides-as-code.md) to enable deployment, add branch-scoped previews, and attach resource references.
+Edit the generated files in `projects/revenue/`, then open a pull request.
 
-When you have a MotherDuck token configured, inspect live create/update/delete actions before applying them:
+## More help
 
-```bash
-make install-deploy
-.venv/bin/md-blueprints plan --target preview --branch feature/example --blueprints events-dashboard
-.venv/bin/md-blueprints cleanup --dry-run --target preview --branch feature/example --blueprints events-dashboard
-```
-
-## Versioning
-
-Customer repositories upgrade by bumping the exact action and CLI versions together. This repository was generated by `md-blueprints __MD_BLUEPRINTS_VERSION__`.
-
-Use the generated exact action tag in workflows:
-
-```yaml
-- uses: motherduckdb/motherduck-blueprints@__MD_BLUEPRINTS_ACTION_TAG__
-  with:
-    command: validate
-```
-
-The local CLI version is pinned in `Makefile` and installed from the matching Git tag:
-
-```make
-CLI_VERSION := __MD_BLUEPRINTS_VERSION__
-```
-
-| action / CLI | schemaVersions supported | upgrade path |
-| --- | --- | --- |
-| v0.x | 1 | Current pre-1.0 contract |
-| v1.x | 1 | First stable customer contract |
-| v2.x | 1 deprecated, removed in v3; 2 current | Run `make doctor` and `make migrate` before bumping |
-
-The scheduled Blueprints Doctor opens an issue when a newer release exists or the exact action and CLI pins drift. Major releases can introduce a new `schemaVersion`; run `make doctor` and `make migrate` first.
-
-## More Detail
-
-- [Repository Reference](docs/repository-reference.md): layout, targets, local commands, CI/CD, and context-layer notes.
-- [blueprint.yml Reference](docs/blueprint-yml-reference.md): complete field reference for blueprint manifests.
-- [Manage Guides as code](docs/guides-as-code.md): scaffold, preview, reference, and deploy version-controlled Guides.
-- [Tooling and Schema Versioning](docs/tooling-and-schema-versioning.md): CLI/action pinning, schema compatibility, and migrations.
-- [Wikipedia Pageviews example](docs/examples/wikipedia-pageviews.md): a Flight that loads public data, publishes a share, and deploys a Dive that reads that share.
-- [NCS Field Recovery Explorer](docs/examples/ncs-field-recovery.md): a complete public-data project with a Flight, share, and Dive.
+- [Setup and troubleshooting](docs/setup-your-repository.md)
+- [Blueprint fields and options](docs/blueprint-yml-reference.md)
+- [GitHub Action inputs](docs/github-action.md)
+- [Guides as code](docs/guides-as-code.md) · [Repository reference](docs/repository-reference.md) · [Upgrades](docs/tooling-and-schema-versioning.md)

--- a/src/md_blueprints/template_repo/docs/blueprint-yml-reference.md
+++ b/src/md_blueprints/template_repo/docs/blueprint-yml-reference.md
@@ -116,6 +116,8 @@ resources:
       cleanup: true
       dropDatabase: false
       targets:
+        staging:
+          name: events_staging
         preview:
           name: events${var.preview_suffix}
           database: events${var.preview_suffix}
@@ -126,7 +128,7 @@ resources:
 
 Required fields are `name` and `database`. Defaults are `access: ORGANIZATION`, `visibility: DISCOVERABLE`, `cleanup: true`, and `dropDatabase: false`.
 
-A hidden share must use restricted access. With the default preview policy, cleanup-sensitive share and database names must contain `target.branch_slug`.
+A hidden share must use restricted access. With the default preview policy, cleanup-sensitive share and database names must contain `target.branch_slug`. When `targets.staging` exists, every rendered staging share name must differ from every production share name. Staging and production database names may match because they belong to separate service accounts.
 
 `includePattern` manages the filtered-share include list. An omitted field leaves the current filter unmanaged, `null` resets the share to unfiltered, and an empty array includes nothing. `grants.roles` and `grants.users` manage `READ` grants. `mode: additive` preserves undeclared grantees, while `mode: authoritative` revokes them.
 
@@ -224,16 +226,16 @@ resources:
       deploy: true
 ```
 
-Roles deploy only to production and require an admin deployment identity. `includedRoles` are roles inherited by the custom role; `members` are MotherDuck usernames. `mode: additive` preserves assignments not listed in the manifest. `mode: authoritative` revokes undeclared direct role and user memberships. Blueprints never delete roles automatically.
+Roles deploy to stable staging and production targets and require an admin deployment identity. They never deploy to preview. `includedRoles` are roles inherited by the custom role; `members` are MotherDuck usernames. `mode: additive` preserves assignments not listed in the manifest. `mode: authoritative` revokes undeclared direct role and user memberships. Blueprints never delete roles automatically.
 
 ## Target and Deployment Semantics
 
-Every resource accepts a `targets.<target>` override. Preview and production rendering validate uniqueness for Flight names, Dive titles, deployed Guide identities, role names, and share names.
+Every resource accepts a `targets.<target>` override. All declared targets validate uniqueness for Flight names, Dive titles, deployed Guide identities, role names, and share names. Staging additionally validates that its share names do not collide with production.
 
 Inputs and repository-local Guide references form a DAG:
 
 - Preview selection expands recursively upstream and downstream.
-- Production selection expands recursively downstream only.
+- Stable staging and production selection expand recursively downstream only.
 - Producers deploy before consumers.
 - A consumer-only production plan requires the producer's output to exist in MotherDuck and fails before mutation otherwise.
 - Cleanup runs in reverse dependency order.

--- a/src/md_blueprints/template_repo/docs/examples/ncs-field-recovery.md
+++ b/src/md_blueprints/template_repo/docs/examples/ncs-field-recovery.md
@@ -61,7 +61,7 @@ make install-deploy
   --blueprints ncs-field-recovery
 ```
 
-Opening a pull request runs the same selection through GitHub Actions. Preview database, share, Flight, and Dive names include the branch scope, and cleanup removes them after the branch closes. The production target uses stable names and runs through the protected `motherduck-production` environment.
+Opening a pull request runs the same selection through GitHub Actions. Preview database, share, Flight, and Dive names include the branch scope, and cleanup removes them after the branch closes. Without staging, merging deploys the stable production target. With staging, merging deploys the `_staging` share through `motherduck-staging`, and a published release deploys the unsuffixed production share through `motherduck-production`. Both accounts may use the `ncs_field_recovery` database name.
 
 ## Reuse the pattern
 
@@ -73,7 +73,7 @@ make new-project field-analytics
 
 Then carry over the patterns that fit your project:
 
-- Use target variables for stable production names and branch-scoped preview names.
+- Use target overrides for distinct staging/production share names and branch-scoped preview names.
 - Set `runOnDeploy: true` when a deployment needs fresh data.
 - Set `waitForRun: success` when downstream resources must wait for the Flight.
 - Keep source-specific metric definitions and limitations in the package README.

--- a/src/md_blueprints/template_repo/docs/examples/wikipedia-pageviews.md
+++ b/src/md_blueprints/template_repo/docs/examples/wikipedia-pageviews.md
@@ -63,7 +63,7 @@ For branch `feature/mock-test`, the share and database render as:
 wikipedia_pageviews_preview_feature_mock_test
 ```
 
-In production, a producer change also redeploys the Dive and reconciles its declared `ready` status. A Dive-only change uses the existing production output and does not rerun the Flight.
+In a stable target, a producer change also redeploys the Dive and reconciles its declared `ready` status. A Dive-only change uses the existing output and does not rerun the Flight. If staging is configured, the staging share renders as `wikipedia_pageviews_staging` while its database remains `wikipedia_pageviews`; a published release deploys the unsuffixed production share.
 
 Cleanup reverses dependencies: it removes the Dive before the Flight, share, and preview database.
 

--- a/src/md_blueprints/template_repo/docs/github-action.md
+++ b/src/md_blueprints/template_repo/docs/github-action.md
@@ -1,0 +1,74 @@
+# Use the GitHub Action
+
+The template already includes deployment and cleanup workflows. You do not need to write a workflow to use it.
+
+Use the action directly when adding Blueprints to an existing repository with a `motherduck.yml` manifest.
+
+## Validate pull requests
+
+Save this as `.github/workflows/validate.yaml`:
+
+```yaml
+name: Validate Blueprints
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: motherduckdb/motherduck-blueprints@v0.4.1
+```
+
+The action installs its own Python dependencies. Validation is the default command and needs no token.
+
+## Deploy manually
+
+Create the `motherduck-production` GitHub Environment and add your service-account token as its `MOTHERDUCK_TOKEN` secret. Save this as `.github/workflows/deploy.yaml`:
+
+```yaml
+name: Deploy Blueprints
+on: [workflow_dispatch]
+permissions:
+  contents: read
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: motherduck-production
+    concurrency:
+      group: motherduck-production
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v7
+      - uses: motherduckdb/motherduck-blueprints@v0.4.1
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        with:
+          command: deploy
+          target: prod
+```
+
+Run it from **Actions → Deploy Blueprints → Run workflow**. It deploys all packages and checks the deployment plan before applying changes. To deploy a subset, add `blueprints: revenue`.
+
+This minimal workflow runs only when you request it. For automatic PR previews, comments, and cleanup, use the template's existing workflows.
+
+## Inputs
+
+| Input | Default | Purpose |
+| --- | --- | --- |
+| `command` | `validate` | CLI command, such as `plan`, `deploy`, `cleanup`, or `doctor`. |
+| `target` | Command default | `prod` for deploy/plan; `preview` for cleanup; validation checks every target. |
+| `branch` | Empty | Required for preview deployment and cleanup. Pass the branch name directly; no extra quotes are needed. |
+| `blueprints` | All packages | Comma-separated package names, such as `orders,revenue`. Dependencies expand according to the target. |
+| `root` | Checkout directory | Directory containing `motherduck.yml`, such as `analytics`. |
+| `args` | Empty | Advanced CLI flags, such as `--json`, `--offline`, or `--dry-run`. |
+| `python-version` | `3.11` | Python runtime installed by the action. |
+
+Named inputs override matching flags in `args`. Existing workflows using only `args` continue to work. The action passes named inputs as literal argument values, including spaces and quotes.
+
+Live commands read `MOTHERDUCK_TOKEN` from the step environment. Select the GitHub Environment on the **job**; the action's `target` input does not select a GitHub Environment for you.
+
+The `stdout` output contains the command's text or JSON result. Assign an `id` to the step to read `steps.<id>.outputs.stdout`. Command failures fail the step.
+
+Pin the action and your local CLI to the same release. See [upgrades](tooling-and-schema-versioning.md).

--- a/src/md_blueprints/template_repo/docs/github-setup.md
+++ b/src/md_blueprints/template_repo/docs/github-setup.md
@@ -1,97 +1,21 @@
-# GitHub Setup
+# Protect your GitHub repository
 
-## 1. Create the Repository
+Complete the [first deployment](setup-your-repository.md) before adding required checks, so GitHub can list the workflow names.
 
-Prefer generating your repository with `md-blueprints init`. See [setup-your-repository.md](setup-your-repository.md) for the full generation and push flow.
+## Protect main
 
-If you are pushing from a local copy manually, create an empty GitHub repository named `motherduck-blueprints`, then push this folder to it.
+In **Settings → Branches** (or your repository rulesets), require pull requests, reviews, and the validation checks before merging to `main`. If you enable Code Owner reviews, first replace the examples in `.github/CODEOWNERS` with your own users or teams.
 
-```bash
-git init
-git add .
-git commit -m "Initial MotherDuck Blueprints repo"
-git branch -M main
-git remote add origin git@github.com:<your-org>/motherduck-blueprints.git
-git push -u origin main
-```
+## Require deployment approval
 
-## 2. Add MotherDuck Secret
+Open **Settings → Environments → motherduck-production** and add required reviewers if your team needs deployment approval.
 
-In GitHub:
+In the default setup, previews, production, and cleanup all use this environment, so its approval and branch rules apply to all three. Allow PR branches if you want previews to deploy. To approve production separately, [add staging](setup-your-repository.md#add-staging-optional).
 
-1. Open Settings.
-2. Open Secrets and variables, then Actions.
-3. Create a repository secret named `MOTHERDUCK_TOKEN`.
-4. Paste a MotherDuck read/write token.
+## Keep credentials and cleanup configured
 
-Use a service account token so deployed resources are owned by automation rather than by an individual user.
+Store `MOTHERDUCK_TOKEN` as an environment secret containing a MotherDuck service-account read/write token. Same-repository deployments fail with a configuration message if it is missing. Fork PRs validate without secrets.
 
-## 3. Add Production Environment Approval
+Keep **Cleanup Preview Blueprints** enabled. It removes preview resources on PR close or branch deletion, checking both branch and base manifests on PR close.
 
-In GitHub:
-
-1. Open Settings.
-2. Open Environments.
-3. Create an environment named `motherduck-production`.
-4. Add required reviewers.
-
-Production blueprint deploys target this environment, so GitHub pauses deployment until an approved reviewer allows it.
-
-## 4. Protect Main
-
-In GitHub:
-
-1. Open Settings.
-2. Open Branches.
-3. Add a branch protection rule for `main`.
-4. Enable "Require a pull request before merging".
-5. Enable required approvals.
-6. Enable "Require review from Code Owners" after updating `.github/CODEOWNERS`.
-7. Require status checks once the first workflow runs have created them.
-
-The repo includes cleanup workflows for preview blueprints. On pull-request close, cleanup checks both the branch and base manifests so resources introduced or removed by the branch are covered. Keep those workflows enabled so PR previews do not linger after branches are closed or deleted.
-
-Pull requests validate even when `MOTHERDUCK_TOKEN` is not configured. Preview deployment is skipped in that case; add the secret when you want PRs to create live MotherDuck previews.
-
-If a target uses a different service account secret, set `targets.<target>.deployment.tokenEnvVar` in `motherduck.yml` and expose that env var in your workflow. The default remains `MOTHERDUCK_TOKEN`.
-
-## 5. Add Assets
-
-Add every deployable asset inside a typed or project package:
-
-```text
-flights/<name>/blueprint.yml
-dives/<name>/blueprint.yml
-guides/<name>/blueprint.yml
-roles/<name>/blueprint.yml
-projects/<name>/blueprint.yml
-```
-
-Use lowercase slug names. No per-package workflow registration is needed: the deploy workflow computes direct changes from `motherduck.yml`, then expands dependencies according to the target.
-
-For a new project, start with:
-
-```bash
-make new-project <blueprint-name>
-```
-
-For separately owned resources, use `make new-flight`, `make new-dive`, `make new-guide`, and `make new-role` instead.
-
-Before opening a PR, run:
-
-```bash
-make setup
-make validate
-make preview-smoke <blueprint-name>
-```
-
-Skip `make preview-smoke` only when the changed blueprint has no Dive.
-For docs-only changes, keep the relevant README or `docs/` page in sync with any behavior you describe.
-
-Live workflows run `md-blueprints plan` before deploy. You can run the same check locally with a MotherDuck token:
-
-```bash
-md-blueprints plan --target preview --branch feature/example --blueprints <blueprint-name>
-```
-
-Pin the exact CLI and action release together when maintaining a customer repository over time. See [Tooling and Schema Versioning](tooling-and-schema-versioning.md) for upgrade and migration guidance.
+For custom workflows, see the [GitHub Action guide](github-action.md). For version updates, see [tooling upgrades](tooling-and-schema-versioning.md).

--- a/src/md_blueprints/template_repo/docs/guides-as-code.md
+++ b/src/md_blueprints/template_repo/docs/guides-as-code.md
@@ -139,7 +139,7 @@ Push the branch and open a pull request. The generated workflow:
 4. Adds the Guide ID and deployment plan to the pull request comment.
 5. Deletes the preview Guide when the pull request closes or the branch is deleted.
 
-After review, merge the pull request. The production workflow publishes stable Guide content, references, metadata, and access through the protected `motherduck-production` environment.
+After review, merge the pull request. Without staging, the merge publishes stable Guide content through `motherduck-production`. With `targets.staging`, the merge publishes to staging; create a non-prerelease GitHub Release when the exact tagged content is ready to deploy through `motherduck-production`.
 
 ## Troubleshooting
 

--- a/src/md_blueprints/template_repo/docs/repository-reference.md
+++ b/src/md_blueprints/template_repo/docs/repository-reference.md
@@ -98,14 +98,16 @@ Direct Git change detection remains package-based. Graph expansion happens when 
 
 ## Targets and Safety
 
-The default targets are:
+The required targets are:
 
 - `preview`: branch-scoped names, disabled Flight schedules, and cleanup enabled.
 - `prod`: stable names deployed through the `motherduck-production` GitHub Environment.
 
+`staging` is the one optional conventional target. Its presence changes CI/CD from direct production deployment to release promotion: previews and `main` use the staging service account, while published releases use production.
+
 Cleanup-sensitive preview shares and databases must contain `${target.branch_slug}`. Preview Flight names and Dive titles must contain the branch or branch slug. Cleanup refuses identifiers that are not branch-scoped or that match production.
 
-A target can select a token environment variable and document its deployment identity:
+A target declares the GitHub Environment that holds its service-account token and documents that identity:
 
 ```yaml
 targets:
@@ -117,6 +119,10 @@ targets:
 ```
 
 Tokens are passed to the DuckDB connection and are never printed.
+
+The default `preview + prod` topology points both targets at `motherduck-production` and deploys `main` directly to production. To isolate production, add `staging`, point both `preview` and `staging` at `motherduck-staging`, and keep `prod` on `motherduck-production`. Each GitHub Environment contains its own secret named `MOTHERDUCK_TOKEN`.
+
+Staging and production may render the same database names because the databases belong to different service accounts. Their share names must differ; Blueprints validates this across every rendered share when staging is configured. A `_staging` suffix is the default scaffold convention. Use a customer-specific logical prefix to reduce the chance of a collision outside the repository.
 
 ## Local Commands
 
@@ -137,9 +143,11 @@ md-blueprints cleanup --dry-run --target preview --branch feature/local
 md-blueprints doctor
 ```
 
+Omit `--blueprints` to select all packages; an explicitly empty selection is an error. `doctor` validates all declared targets, including rendered resources, and exits unsuccessfully if the manifest is missing or validation fails. Preview commands preserve the existing Dive entrypoint if source selection fails.
+
 `make new-blueprint NAME` remains a compatibility alias for `make new-project NAME`. For a Dive backed by another repository, use `make new-dive NAME URL=md:_share/...`. If a package declares several Dives, pass `DIVE=<resource-key>` to preview commands.
 
-`make validate` renders preview and production, validates contracts and uniqueness, checks Flight Python syntax and source boundaries, and validates Dive mounts and Guide references. `md-blueprints plan` queries live state without mutations. A non-selected production producer must already expose its declared share or planning fails before deployment.
+`make validate` renders every declared target, validates contracts and uniqueness, checks Flight Python syntax and source boundaries, and validates Dive mounts and Guide references. `md-blueprints plan` queries live state without mutations. A non-selected stable producer must already expose its declared share or planning fails before deployment.
 
 ## Dives
 
@@ -153,11 +161,11 @@ See [Manage Guides as code](guides-as-code.md) for the end-to-end workflow, incl
 
 ## RBAC
 
-Declare custom roles under `resources.roles` or scaffold a role package with `make new-role`. Roles deploy only in production, before resources that may grant access to them. Share `grants` can target roles and users in additive or authoritative mode. Role and organization-Guide changes run an admin capability preflight before the first mutation.
+Declare custom roles under `resources.roles` or scaffold a role package with `make new-role`. Roles deploy to stable staging and production targets, but never to preview, before resources that may grant access to them. Share `grants` can target roles and users in additive or authoritative mode. Role and organization-Guide changes run an admin capability preflight before the first mutation.
 
 ## CI/CD
 
-Pull requests compute directly changed packages, expand the preview dependency graph, plan live changes, deploy branch-scoped resources, and comment with plans and preview links. Pushes to `main` expand production changes downstream and deploy through the protected production environment. Closing a PR or deleting a branch triggers dependency-safe preview cleanup.
+Pull requests compute directly changed packages, expand the preview dependency graph, plan live changes, deploy branch-scoped resources, and comment with plans and preview links. Without staging, pushes to `main` expand changes downstream and deploy production. With staging, pushes to `main` deploy staging and a published non-prerelease GitHub Release verifies and deploys the exact tagged commit to production. Closing a PR or deleting a branch triggers dependency-safe preview cleanup through the preview target's GitHub Environment.
 
 ## Included examples
 

--- a/src/md_blueprints/template_repo/docs/setup-your-repository.md
+++ b/src/md_blueprints/template_repo/docs/setup-your-repository.md
@@ -1,203 +1,121 @@
-# Set Up Your Repository
+# Set up your first deployment
 
-Use `md-blueprints init` to generate a typed MotherDuck Blueprints repository, connect it to MotherDuck with a service account token, then customize or add independently deployable packages.
+Start with the [template repository](https://github.com/motherduckdb/blueprints-template/generate). Choose a private repository. It includes the workflows and public-data examples, so you can try deployment without installing anything locally.
 
-Use `flights/`, `dives/`, `guides/`, and `roles/` when those resources have different owners or lifecycles. Use `projects/` when several resource types genuinely ship, preview, and roll back together. Existing `blueprints/` packages remain supported.
+## 1. Connect MotherDuck
 
-## 1. Generate the Repository
+Create a MotherDuck service account with a read/write token and permission to create the example resources. In your new GitHub repository, open **Settings → Environments**, create `motherduck-production`, and add the token as an environment secret named `MOTHERDUCK_TOKEN`.
 
-Install the released CLI and generate the customer file set:
+The default setup uses this account for both previews and production. Never commit the token. If your GitHub plan does not offer Environments for this repository, resolve that before deploying; these workflows require an environment secret.
+
+## 2. Open your first preview
+
+In GitHub, edit the `description` in `flights/wikipedia-pageviews-ingest/blueprint.yml`. Choose **Create a new branch for this commit** and open a pull request. Start with the Flight package so the first production deployment creates the data before the dashboard.
+
+Wait for **Deploy Blueprints** to finish. It loads public Wikipedia data and posts a comment containing the plan and preview links. Open the Dive link to see the dashboard.
+
+Change an example file for this first PR: an empty commit or a top-level README-only change does not trigger deployment. Fork PRs validate without deployment credentials.
+
+## 3. Deploy production
+
+Merge the PR into `main`. The workflow deploys the changed packages to production and shows its plan in the Actions job summary. Preview resources are cleaned up when the PR closes.
+
+The repository also includes the NCS example under `projects/ncs-field-recovery/`. A manual deployment with no package selection deploys all included examples. Remove unwanted packages before deploying them. Removing source files does not delete already-deployed production resources.
+
+## Work locally (optional)
+
+Install Python 3.10+ and Git, clone your repository, and run:
 
 ```bash
-python3 -m venv .venv
-.venv/bin/python -m pip install "md-blueprints==__MD_BLUEPRINTS_VERSION__"
-.venv/bin/md-blueprints init motherduck-blueprints
-cd motherduck-blueprints
+make validate
 ```
 
-Create a GitHub repository and push the generated files:
-
-```bash
-git init
-git add .
-git commit -m "Initial MotherDuck Blueprints repo"
-gh repo create <your-org>/motherduck-blueprints --private --source . --remote origin --push
-```
-
-## 2. Create a MotherDuck Service Account Token
-
-In your MotherDuck organization:
-
-1. Create a service account for CI deployments.
-2. Grant it the minimum database privileges needed by the blueprints. Use the `admin` preset role when the repository manages custom roles or organization-wide Guides.
-3. Generate a read/write token.
-4. Store the token somewhere secure long enough to add it to GitHub.
-
-Use a service account token rather than a personal token so deployed Dives, Flights, tables, and shares are owned by a shared automation identity.
-
-## 3. Add GitHub Secrets
-
-In your repository:
-
-1. Open Settings.
-2. Open Secrets and variables, then Actions.
-3. Add a repository secret named `MOTHERDUCK_TOKEN`.
-4. Paste the MotherDuck service account token.
-
-Do not commit tokens to the repository.
-
-## 4. Configure Deployment Approvals
-
-Create a GitHub Environment named `motherduck-production`.
-
-Recommended settings:
-
-- Add required reviewers.
-- Restrict who can approve production deployments if needed.
-- Keep the environment name exactly `motherduck-production`, because production jobs reference it.
-
-## 5. Protect `main`
-
-Add branch protection for `main`.
-
-Recommended settings:
-
-- Require a pull request before merging.
-- Require approvals.
-- Require review from Code Owners after `.github/CODEOWNERS` is updated.
-- Require the relevant workflow checks after the first PR has run them.
-
-## 6. Run Local Validation
-
-Before touching MotherDuck, run:
+For dashboard development, install Node.js 22+ and run:
 
 ```bash
 make setup
-make validate
 make preview-smoke wikipedia-pageviews
 ```
 
-`make validate` checks manifests and rendered targets. `make preview-smoke` builds a selected Dive locally without contacting MotherDuck.
+Validation and preview builds do not connect to MotherDuck. To open a live local preview after deploying the data, set `VITE_MOTHERDUCK_TOKEN` in the ignored `.dive-preview/.env`, then run `make preview wikipedia-pageviews`. Keep this local development token private.
 
-If you keep a Dive in the repo, also run a finite local preview build:
+Create a new pipeline and dashboard with `make new-project revenue`. Edit its files under `projects/revenue/`, run `make validate`, and open a PR. For separate pipeline and dashboard packages, see the [repository reference](repository-reference.md).
 
-```bash
-make preview-smoke <blueprint-name>
-```
+## If something does not work
 
-PR validation still runs if `MOTHERDUCK_TOKEN` has not been added yet, but live preview deployment is skipped until the secret exists.
+| What you see | What to check |
+| --- | --- |
+| No deployment run | Change a file inside an example package and open the PR against `main`. |
+| Waiting for approval | Approve the deployment in Actions if you configured required environment reviewers. |
+| Missing token | Put `MOTHERDUCK_TOKEN` in **Settings → Environments → motherduck-production**, not repository secrets. |
+| Permission error from MotherDuck | Check the service account's privileges. Custom roles and organization-wide Guides require an admin identity. |
+| Local Python setup fails | Select a working interpreter, for example `make validate PYTHON=python3.13`. |
+| No preview comment on a fork PR | Expected: fork PRs validate only. Use a branch in your own repository to deploy. |
 
-## 7. Run a Preview PR
+Before team use, [configure branch protection and deployment approvals](github-setup.md). In the default setup, environment approval rules apply to previews and cleanup as well as production.
 
-Create a branch and make a small change, for example edit the Wikipedia Dive docs or metadata.
+## Add staging (optional)
 
-```bash
-git checkout -b test/wikipedia-blueprint
-git commit --allow-empty -m "Test Wikipedia blueprint preview"
-git push -u origin test/wikipedia-blueprint
-gh pr create --fill
-```
+Add staging when production credentials must not be available to pull requests or ordinary `main` deployments.
 
-Expected preview flow:
-
-1. `Deploy Blueprints` validates manifests.
-2. Directly changed packages are discovered from `motherduck.yml`, then the preview selection expands upstream and downstream.
-3. The workflow runs a read-only preview plan.
-4. Preview Flights deploy with schedules disabled.
-5. Preview Flights run when `runOnDeploy` is true.
-6. Preview databases and shares are created with the branch slug.
-7. Dives deploy after required shares are resolvable.
-8. Preview Dives are enforced as `draft`.
-9. Opt-in preview Guides deploy after their references resolve.
-10. A PR comment lists the plan plus preview Flight, share, Dive, and Guide details.
-
-## 8. Verify Cleanup
-
-Close the PR or delete the branch.
-
-Expected cleanup flow:
-
-1. Preview Guides are deleted.
-2. Preview Dives are deleted.
-3. Preview Flights are deleted.
-4. Preview shares are dropped.
-5. Preview databases are dropped when `dropDatabase: true`.
-
-Cleanup refuses to drop share/database names that do not include the branch slug.
-
-You can preview cleanup locally before closing a PR:
-
-```bash
-md-blueprints cleanup --dry-run --target preview --branch test/wikipedia-blueprint
-```
-
-## 9. Deploy to Production
-
-Merge the PR to `main`.
-
-Expected production flow:
-
-1. `Deploy Blueprints` runs on `main`.
-2. GitHub waits for approval in `motherduck-production`.
-3. The workflow writes a read-only production plan to the GitHub job summary.
-4. Production roles and memberships reconcile.
-5. Production Flights deploy.
-6. Flights run when `runOnDeploy` is true.
-7. Required shares, filters, and grants reconcile.
-8. Production Dives deploy and reconcile explicitly declared governance statuses.
-9. Production Guides deploy after their references resolve.
-
-The generated examples use `ready` in production and `draft` in preview. Omitting production `status` preserves the live value. Endorsing a Dive requires an organization-admin deployment identity.
-
-## 10. Customize the Blueprints
-
-You can then:
-
-- Scaffold a producer with `make new-flight events-ingest` and consume it with `make new-dive events-dashboard INPUT=events-ingest.data`.
-- Scaffold a complete co-owned package with `make new-project revenue-overview`.
-- Connect same-repository packages through `outputs` and `inputs`; use literal share URLs for external repositories.
-- Replace the bundled Wikipedia and NCS public-data examples with your own packages.
-- Add target `deployment.tokenEnvVar` and `deployment.identity` metadata in `motherduck.yml` if preview and production use different service account secrets.
-- Publish versioned Guide assets below `guides/` with `resources.guides` and `deploy: true`; follow [Manage Guides as code](guides-as-code.md) for preview naming, access, and references.
-- Manage custom roles below `roles/` with `resources.roles`; use `mode: authoritative` only when the repository owns the complete membership set.
-- Update `.github/CODEOWNERS`.
-
-## 11. Keep Tooling in Sync
-
-After repository creation, treat the versioned `md-blueprints` repository tags as the long-term upgrade surface. The generated files are the starting point, while the CLI source and action carry schema validation, deployment behavior, and migrations.
-
-The generated `Makefile` pins the CLI version in `CLI_VERSION` and installs it from the matching Git tag, so local installs stay aligned with the release that generated the repository. Install and validate with:
-
-```bash
-make setup
-make validate
-```
-
-Use `make install-deploy` before live local plan/deploy/cleanup commands. It installs the deploy extra, which includes the DuckDB Python runtime dependencies needed for MotherDuck connections:
-
-```bash
-make install-deploy
-```
-
-To upgrade, bump `CLI_VERSION` in `Makefile` and every action tag in `.github/workflows/` to the same exact release. Blueprints Doctor reports newer releases and rejects drift between those pins.
-
-The action tag is the preferred CI path for customer repositories.
-
-When using the repository action, pin the exact release in customer workflows:
+1. Create a second MotherDuck service account for staging.
+2. Create a GitHub Environment named `motherduck-staging` and add its token as an environment secret named `MOTHERDUCK_TOKEN`.
+3. Change `targets.preview.environment` and `targets.preview.deployment.identity` to the staging environment and service account.
+4. Add the conventional staging target:
 
 ```yaml
-- uses: motherduckdb/motherduck-blueprints@__MD_BLUEPRINTS_ACTION_TAG__
-  with:
-    command: validate
+targets:
+  preview:
+    mode: preview
+    environment: motherduck-staging
+    deployment:
+      tokenEnvVar: MOTHERDUCK_TOKEN
+      identity: GitHub Actions staging service account
+    policies:
+      disableSchedules: true
+      cleanup: true
+      requireBranchSlugInDataResources: true
+
+  staging:
+    mode: production
+    environment: motherduck-staging
+    deployment:
+      tokenEnvVar: MOTHERDUCK_TOKEN
+      identity: GitHub Actions staging service account
+
+  prod:
+    mode: production
+    environment: motherduck-production
+    deployment:
+      tokenEnvVar: MOTHERDUCK_TOKEN
+      identity: GitHub Actions production service account
 ```
 
-Before adopting a new schema version, run:
+5. Give every produced staging share a distinct physical name:
 
-```bash
-md-blueprints doctor
-md-blueprints migrate --to latest
+```yaml
+resources:
+  shares:
+    events:
+      name: acme_events
+      database: events
+      targets:
+        staging:
+          name: acme_events_staging
 ```
 
-Review migration output before applying it with `--write`.
+The database can remain `events` because each service account owns its own database. The share name must differ across staging and production. Use a customer-specific logical prefix because Blueprints can detect collisions between declared targets but cannot inspect unrelated accounts.
 
-When you change repository commands, resource behavior, target policies, or package layout, update the matching docs in the same pull request.
+After staging is present, the workflow changes automatically:
+
+1. Pull requests deploy branch-scoped previews through `motherduck-staging`.
+2. Merges to `main` deploy stable staging resources.
+3. A published, non-prerelease GitHub Release checks out its exact tag and deploys every blueprint to production.
+
+Promotion reconciles the tagged code under the production service account. It does not copy staging databases or data.
+
+## Keep the tooling current
+
+Update `CLI_VERSION` in the generated `Makefile` and the action tags in `.github/workflows/` to the same release. The scheduled Doctor workflow reports outdated tooling and configuration problems. See [upgrades and migrations](tooling-and-schema-versioning.md).
+
+For live local commands, run `make install-deploy` first. For a custom workflow, see [GitHub Action inputs](github-action.md).

--- a/src/md_blueprints/template_repo/docs/tooling-and-schema-versioning.md
+++ b/src/md_blueprints/template_repo/docs/tooling-and-schema-versioning.md
@@ -21,7 +21,7 @@ Upgrade local tooling by bumping `CLI_VERSION` in `Makefile` and every Blueprint
 Customer workflows should pin an immutable release tag:
 
 ```yaml
-- uses: motherduckdb/motherduck-blueprints@__MD_BLUEPRINTS_ACTION_TAG__
+- uses: motherduckdb/motherduck-blueprints@v0.4.1
   with:
     command: validate
 ```
@@ -42,6 +42,8 @@ make preview-smoke <blueprint-name>
 ```
 
 The scheduled `Blueprints Doctor` workflow runs `doctor --check-updates` and opens or updates one tracking issue when a release is stale, action and CLI pins drift, or the project schema needs migration.
+
+Doctor also reports deployment-model drift. Repository-level `MOTHERDUCK_TOKEN` workflows are deprecated: generated workflows now select the GitHub Environment declared by each target and read that environment's `MOTHERDUCK_TOKEN`. Existing pre-1.0 workflows remain executable during the compatibility window, but the legacy secret model is scheduled for removal at the next major release.
 
 ## Schema Source of Truth
 
@@ -91,7 +93,7 @@ The internal migration contract is:
 MIGRATIONS: dict[tuple[int, int], Callable[[dict[str, object]], dict[str, object]]] = {}
 ```
 
-Each migration is a pure document transform. The command loads `motherduck.yml` and included `blueprint.yml` files, applies the migration path, emits a unified diff, optionally writes files, and revalidates migrated documents against the target schema.
+Each migration is a pure document transform. The command loads `motherduck.yml` and included `blueprint.yml` files, applies the migration path, validates every migrated document against the target schema, and emits a unified diff. With `--write`, files are written only after every document passes validation. Includes stay within the repository, overlapping matches are deduplicated, and every document must declare an integer `schemaVersion`. File writes are sequential; an operating-system write failure can still leave a partial migration.
 
 For `schemaVersion: 1`, `md-blueprints migrate --to latest` prints that no migration is needed.
 
@@ -117,7 +119,7 @@ One-time template setup: create `motherduckdb/blueprints-template`, mark it as a
 Before creating a release tag:
 
 ```bash
-make release-check TAG=v__MD_BLUEPRINTS_VERSION__
+make release-check TAG=v0.4.1
 make release-external-check
 make validate
 make mock-test

--- a/src/md_blueprints/template_repo/flights/README.md
+++ b/src/md_blueprints/template_repo/flights/README.md
@@ -1,3 +1,3 @@
 # Flights
 
-Place independently owned Flight producers below this root. A Flight blueprint may declare shares and named outputs for downstream consumers.
+Place independently owned Flight producers below this root. A Flight blueprint may declare shares and named outputs for downstream consumers. If the repository configures staging, give every staging share a distinct physical name such as `<share>_staging`; its database name may stay the same as production.

--- a/src/md_blueprints/template_repo/flights/wikipedia-pageviews-ingest/blueprint.yml
+++ b/src/md_blueprints/template_repo/flights/wikipedia-pageviews-ingest/blueprint.yml
@@ -31,6 +31,8 @@ resources:
       cleanup: true
       dropDatabase: false
       targets:
+        staging:
+          name: ${var.share}_staging
         preview:
           name: ${var.share}${var.preview_suffix}
           database: ${var.database}${var.preview_suffix}

--- a/src/md_blueprints/template_repo/motherduck.yml
+++ b/src/md_blueprints/template_repo/motherduck.yml
@@ -20,9 +20,10 @@ targets:
   preview:
     mode: preview
     default: true
+    environment: motherduck-production
     deployment:
       tokenEnvVar: MOTHERDUCK_TOKEN
-      identity: GitHub Actions preview service account
+      identity: GitHub Actions production service account
     policies:
       disableSchedules: true
       cleanup: true

--- a/src/md_blueprints/template_repo/projects/ncs-field-recovery/blueprint.yml
+++ b/src/md_blueprints/template_repo/projects/ncs-field-recovery/blueprint.yml
@@ -31,6 +31,8 @@ resources:
       cleanup: true
       dropDatabase: false
       targets:
+        staging:
+          name: ${var.share}_staging
         preview:
           name: ${var.share}${var.preview_suffix}
           database: ${var.database}${var.preview_suffix}

--- a/src/md_blueprints/template_repo/roles/README.md
+++ b/src/md_blueprints/template_repo/roles/README.md
@@ -1,3 +1,3 @@
 # Roles
 
-Place production RBAC role packages below this root. Role deployment is disabled for preview targets. Use `mode: additive` to preserve undeclared assignments or `mode: authoritative` to revoke assignments not declared in the blueprint.
+Place stable-environment RBAC role packages below this root. Roles deploy to staging and production but remain disabled for preview targets. Use `mode: additive` to preserve undeclared assignments or `mode: authoritative` to revoke assignments not declared in the blueprint.

--- a/src/md_blueprints/template_repo/schemas/v1/motherduck-root.schema.json
+++ b/src/md_blueprints/template_repo/schemas/v1/motherduck-root.schema.json
@@ -29,6 +29,7 @@
       "additionalProperties": { "$ref": "#/$defs/target" },
       "properties": {
         "preview": { "$ref": "#/$defs/target" },
+        "staging": { "$ref": "#/$defs/target" },
         "prod": { "$ref": "#/$defs/target" }
       }
     }
@@ -57,7 +58,7 @@
       "properties": {
         "mode": { "type": "string", "minLength": 1 },
         "default": { "type": "boolean" },
-        "environment": { "type": "string" },
+        "environment": { "type": "string", "minLength": 1 },
         "deployment": {
           "type": "object",
           "additionalProperties": false,

--- a/src/md_blueprints/template_repo/templates/blueprint/README.md
+++ b/src/md_blueprints/template_repo/templates/blueprint/README.md
@@ -10,7 +10,7 @@ This generated blueprint is a complete `projects/` starter. It deploys a Flight 
 
 The Dive deploys as `draft` in pull-request previews and `ready` in production. Change the production status to `endorsed` only when an organization admin has approved it as a trusted source of truth; use `archived` to retire it without deleting its URL and history.
 
-The production target writes to the stable `__DATABASE_NAME__` database and share. The preview target writes to `__DATABASE_NAME___preview_${target.branch_slug}`, disables schedules, runs once on deploy, and cleans up the preview share and database when the branch closes.
+The production target writes to the stable `__DATABASE_NAME__` database and share. If the repository adds `targets.staging`, staging uses the same database name under its own service account and publishes the distinct `__DATABASE_NAME___staging` share. The preview target writes to `__DATABASE_NAME___preview_${target.branch_slug}`, disables schedules, runs once on deploy, and cleans up the preview share and database when the branch closes.
 
 ## Replace the Starter Logic
 

--- a/src/md_blueprints/template_repo/templates/blueprint/blueprint.yml
+++ b/src/md_blueprints/template_repo/templates/blueprint/blueprint.yml
@@ -28,6 +28,8 @@ resources:
       cleanup: true
       dropDatabase: false
       targets:
+        staging:
+          name: ${var.share}_staging
         preview:
           name: ${var.share}${var.preview_suffix}
           database: ${var.database}${var.preview_suffix}

--- a/templates/blueprint/README.md
+++ b/templates/blueprint/README.md
@@ -10,7 +10,7 @@ This generated blueprint is a complete `projects/` starter. It deploys a Flight 
 
 The Dive deploys as `draft` in pull-request previews and `ready` in production. Change the production status to `endorsed` only when an organization admin has approved it as a trusted source of truth; use `archived` to retire it without deleting its URL and history.
 
-The production target writes to the stable `__DATABASE_NAME__` database and share. The preview target writes to `__DATABASE_NAME___preview_${target.branch_slug}`, disables schedules, runs once on deploy, and cleans up the preview share and database when the branch closes.
+The production target writes to the stable `__DATABASE_NAME__` database and share. If the repository adds `targets.staging`, staging uses the same database name under its own service account and publishes the distinct `__DATABASE_NAME___staging` share. The preview target writes to `__DATABASE_NAME___preview_${target.branch_slug}`, disables schedules, runs once on deploy, and cleans up the preview share and database when the branch closes.
 
 ## Replace the Starter Logic
 

--- a/templates/blueprint/blueprint.yml
+++ b/templates/blueprint/blueprint.yml
@@ -28,6 +28,8 @@ resources:
       cleanup: true
       dropDatabase: false
       targets:
+        staging:
+          name: ${var.share}_staging
         preview:
           name: ${var.share}${var.preview_suffix}
           database: ${var.database}${var.preview_suffix}

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+def test_action_defaults_to_validation() -> None:
+    action = yaml.safe_load((Path(__file__).resolve().parents[1] / "action.yml").read_text())
+    assert action["inputs"]["command"]["default"] == "validate"
+    assert action["inputs"]["command"]["required"] is False
+
+
+@pytest.mark.parametrize("returncode", [0, 1])
+def test_action_passes_named_inputs_literally_and_preserves_exit_status(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], returncode: int,
+) -> None:
+    action = yaml.safe_load((Path(__file__).resolve().parents[1] / "action.yml").read_text())
+    step = next(step for step in action["runs"]["steps"] if step.get("id") == "run")
+    source = step["run"].split("python - <<'PY' | tee \"$stdout_file\"\n")[1].split("\nPY\n")[0]
+    values = {
+        "COMMAND": "plan",
+        "ARGS": "--target prod --json",
+        "TARGET": "preview",
+        "ROOT": "customer analytics",
+        "BRANCH": 'feature/customer-"quote"-$(literal)',
+        "BLUEPRINTS": "orders,revenue",
+    }
+    for key, value in values.items():
+        monkeypatch.setenv(f"MD_BLUEPRINTS_{key}", value)
+    received: list[str] = []
+
+    def run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        received.extend(argv)
+        assert not kwargs.get("shell")
+        return subprocess.CompletedProcess(argv, returncode, stdout="plan output\n")
+
+    monkeypatch.setattr(subprocess, "run", run)
+    with pytest.raises(SystemExit) as result:
+        exec(compile(source, "action.yml", "exec"), {})
+
+    assert result.value.code == returncode
+    assert received == [
+        "md-blueprints", "plan", "--target", "prod", "--json",
+        "--root=customer analytics", "--target=preview",
+        '--branch=feature/customer-"quote"-$(literal)', "--blueprints=orders,revenue",
+    ]
+    assert capsys.readouterr().out == "plan output\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from md_blueprints import cli
 
 
@@ -22,6 +24,23 @@ def test_cli_returns_zero_for_successful_validate() -> None:
 
 def test_cli_returns_one_for_validation_error(tmp_path: Path) -> None:
     assert cli.main(["validate", "--root", str(tmp_path / "missing")]) == 1
+
+
+@pytest.mark.parametrize("selection", ["", " ", ", ,"])
+def test_cli_rejects_empty_explicit_selection(selection: str, capsys: pytest.CaptureFixture[str]) -> None:
+    assert cli.main(["deploy", "--blueprints", selection]) == 1
+    assert "must contain at least one blueprint name" in capsys.readouterr().err
+
+
+def test_doctor_returns_failure_for_invalid_resources(capsys: pytest.CaptureFixture[str]) -> None:
+    assert cli.main(["doctor", "--root", str(FIXTURES / "invalid-preview"), "--offline"]) == 1
+    output = capsys.readouterr().out
+    assert "validation: failed" in output
+    assert "validation: passed" not in output
+
+
+def test_doctor_returns_failure_for_missing_manifest(tmp_path: Path) -> None:
+    assert cli.main(["doctor", "--root", str(tmp_path), "--offline"]) == 1
 
 
 def test_cli_render_validates_the_selected_target() -> None:

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from pathlib import Path
 
 import pytest
@@ -21,6 +22,33 @@ def test_cleanup_respects_disabled_target_policy() -> None:
 
     with pytest.raises(ValidationError, match="cleanup is disabled"):
         Deployer(project).cleanup_plan(target="preview", branch="feature/test", names=None)
+
+
+def test_cleanup_compares_preview_against_staging_when_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = Project(FIXTURES / "simple")
+    targets = project.manifest["targets"]
+    assert isinstance(targets, dict)
+    targets["staging"] = copy.deepcopy(targets["prod"])
+    deployer = Deployer(project)
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(deployer, "_prepare_live_command", lambda target, operation: None)
+
+    def capture_cleanup(
+        rendered: list[RenderedBlueprint],
+        rendered_branch_slug: str,
+        **kwargs: object,
+    ) -> list[PlanRecord]:
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(deployer, "_build_cleanup_plan", capture_cleanup)
+
+    deployer.cleanup_plan(target="preview", branch="feature/test", names=None)
+
+    assert captured["stable_target"] == "staging"
 
 
 def test_cleanup_plan_refuses_share_without_branch_slug(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -57,6 +57,8 @@ def test_init_writes_customer_template_with_stamped_versions(tmp_path: Path) -> 
     requirements = (target / "flights/wikipedia-pageviews-ingest/src/requirements.txt").read_text(encoding="utf-8")
 
     assert f"CLI_VERSION := {__version__}" in makefile
+    assert "PYTHON ?= python3" in makefile
+    assert "$(PYTHON) -m venv .venv" in makefile
     assert "CLI_SOURCE := git+https://github.com/motherduckdb/motherduck-blueprints.git@v$(CLI_VERSION)" in makefile
     assert 'installed_version="$$( [ -x "$(CLI)" ] && "$(CLI)" --version' in makefile
     assert 'if [ "$$installed_version" != "$(CLI_VERSION)" ]; then' in makefile
@@ -64,9 +66,18 @@ def test_init_writes_customer_template_with_stamped_versions(tmp_path: Path) -> 
     assert "install-deploy: $(CLI)" in makefile
     assert '.venv/bin/python -m pip install "md-blueprints[deploy] @ $(CLI_SOURCE)"' in makefile
     assert f"motherduckdb/motherduck-blueprints@{action_tag()}" in deploy_workflow
+    assert "md-blueprints-environment-model: v1" in deploy_workflow
+    assert "targets.staging" in deploy_workflow
+    assert "github.event_name == 'release'" in deploy_workflow
+    assert "environment: ${{ needs.compute_changes.outputs.target_environment }}" in deploy_workflow
+    assert "Release tag $RELEASE_TAG does not point to a commit" in deploy_workflow
+    assert 'git", "show", f"origin/{base_ref}:motherduck.yml"' in deploy_workflow
+    assert "branch_identity != base_identity" in deploy_workflow
+    assert "must use deployment.tokenEnvVar: MOTHERDUCK_TOKEN" in deploy_workflow
     assert '"guides/**"' in deploy_workflow
     assert '"roles/**"' in deploy_workflow
     assert f"motherduckdb/motherduck-blueprints@{action_tag()}" in cleanup_workflow
+    assert "environment: ${{ needs.resolve-environment.outputs.environment }}" in cleanup_workflow
     assert "github.event.pull_request.head.sha" in cleanup_workflow
     assert "github.event.pull_request.base.sha" in cleanup_workflow
     assert "github.event.pull_request.head.repo.full_name == github.repository" in cleanup_workflow
@@ -74,6 +85,10 @@ def test_init_writes_customer_template_with_stamped_versions(tmp_path: Path) -> 
     assert "__MD_BLUEPRINTS_" not in readme
     assert "mock-test" not in makefile
     assert "package-smoke" not in makefile
+
+    manifest = (target / "motherduck.yml").read_text(encoding="utf-8")
+    assert "staging:" not in manifest
+    assert manifest.count("environment: motherduck-production") == 2
 
     Project(target).validate()
 
@@ -83,6 +98,15 @@ def test_deploy_workflow_watches_all_deployable_roots() -> None:
 
     for root in ["flights", "dives", "guides", "roles", "projects"]:
         assert f'"{root}/**"' in workflow
+
+
+def test_deploy_workflow_derives_staging_and_release_behavior_from_manifest() -> None:
+    workflow = (REPO_ROOT / ".github/workflows/deploy_blueprints.yaml").read_text(encoding="utf-8")
+
+    assert 'staging_enabled = "staging" in targets' in workflow
+    assert 'target = "staging" if staging_enabled else "prod"' in workflow
+    assert "deployment_enabled = staging_enabled" in workflow
+    assert "target: prod" in workflow
 
 
 def test_ci_runs_for_all_main_and_pull_request_changes() -> None:

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -66,3 +66,81 @@ def test_doctor_rejects_action_and_cli_pin_drift(
 
     with pytest.raises(ValidationError, match="action and CLI pins are not aligned"):
         run_doctor(tmp_path, check_updates=True)
+
+
+def test_doctor_warns_about_legacy_repository_secret_workflow(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    run_init(tmp_path)
+    workflow = tmp_path / ".github/workflows/deploy_blueprints.yaml"
+    workflow.write_text(
+        workflow.read_text(encoding="utf-8").replace("# md-blueprints-environment-model: v1\n", ""),
+        encoding="utf-8",
+    )
+
+    run_doctor(tmp_path)
+
+    assert "repository-level MOTHERDUCK_TOKEN workflow is deprecated" in capsys.readouterr().out
+
+
+def test_doctor_warns_when_target_environment_metadata_is_missing(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    run_doctor(FIXTURES / "medium")
+
+    output = capsys.readouterr().out
+    assert "target 'preview' does not declare a GitHub Environment" in output
+    assert "target 'prod' does not document deployment.identity" in output
+
+
+def test_doctor_warns_about_noncanonical_environment_secret_name(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    run_doctor(FIXTURES / "simple")
+
+    assert "generated GitHub Environment workflows require the canonical secret name" in capsys.readouterr().out
+
+
+def test_doctor_warns_about_staging_workflow_routing(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    run_init(tmp_path)
+    manifest = tmp_path / "motherduck.yml"
+    manifest_text = manifest.read_text(encoding="utf-8")
+    manifest_text = manifest_text.replace(
+        "environment: motherduck-production",
+        "environment: motherduck-staging",
+        1,
+    ).replace(
+        "identity: GitHub Actions production service account",
+        "identity: GitHub Actions staging service account",
+        1,
+    )
+    manifest_text = manifest_text.replace(
+        "  prod:\n",
+        """  staging:
+    mode: production
+    environment: motherduck-staging
+    deployment:
+      tokenEnvVar: MOTHERDUCK_TOKEN
+      identity: GitHub Actions staging service account
+
+  prod:
+""",
+    )
+    manifest.write_text(manifest_text, encoding="utf-8")
+    workflow = tmp_path / ".github/workflows/deploy_blueprints.yaml"
+    workflow.write_text(
+        workflow.read_text(encoding="utf-8")
+        .replace('target = "staging" if staging_enabled else "prod"', 'target = "prod"')
+        .replace("github.event_name == 'release'", "github.event_name == 'disabled-release'"),
+        encoding="utf-8",
+    )
+
+    run_doctor(tmp_path)
+
+    output = capsys.readouterr().out
+    assert "default-branch workflow does not select staging" in output
+    assert "production is not deployed from a published GitHub Release" in output

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 import md_blueprints.migrations as migrations
-from md_blueprints.migrations import run_migrate
+from md_blueprints.migrations import project_manifest_files, run_migrate
 from md_blueprints.schema import ValidationError
 
 
@@ -21,6 +21,52 @@ def test_migrate_latest_is_idempotent_for_current_schema(capsys: pytest.CaptureF
 def test_migrate_from_mismatch_rejects_project() -> None:
     with pytest.raises(ValidationError, match="--from 2 does not match project schemaVersion set: 1"):
         run_migrate(FIXTURES / "simple", from_version=2, to_version="latest", write=False)
+
+
+def test_migration_rejects_external_symlinks(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    write_v1_project(root)
+    outside = tmp_path / "outside.yml"
+    outside.write_text("schemaVersion: 1\n", encoding="utf-8")
+    blueprint = root / "blueprints/demo/blueprint.yml"
+    blueprint.unlink()
+    blueprint.symlink_to(outside)
+    with pytest.raises(ValidationError, match="must stay within"):
+        run_migrate(root, from_version=None, to_version="latest", write=True)
+    assert outside.read_text(encoding="utf-8") == "schemaVersion: 1\n"
+
+
+def test_migration_deduplicates_overlapping_includes(tmp_path: Path) -> None:
+    write_v1_project(tmp_path)
+    manifest = tmp_path / "motherduck.yml"
+    text = manifest.read_text(encoding="utf-8")
+    manifest.write_text(text.replace("include:\n", "include:\n  - '**/blueprint.yml'\n"), encoding="utf-8")
+    assert len(project_manifest_files(tmp_path)) == 2
+
+
+def test_migration_rejects_missing_document_version(tmp_path: Path) -> None:
+    write_v1_project(tmp_path)
+    blueprint = tmp_path / "blueprints/demo/blueprint.yml"
+    blueprint.write_text("name: demo\n", encoding="utf-8")
+    with pytest.raises(ValidationError, match="schemaVersion must be an integer"):
+        run_migrate(tmp_path, from_version=None, to_version="latest", write=True)
+
+
+def test_migration_validates_all_documents_before_writing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    write_v1_project(tmp_path)
+    install_fake_v2_migration(monkeypatch)
+    originals = {path: path.read_bytes() for path in project_manifest_files(tmp_path)}
+
+    class RejectBlueprint:
+        def validate(self, data: object, schema_name: str) -> None:
+            if schema_name == "blueprint.schema.json":
+                raise ValidationError("invalid migrated blueprint")
+
+    monkeypatch.setattr(migrations, "SchemaValidator", RejectBlueprint)
+    with pytest.raises(ValidationError, match="invalid migrated blueprint"):
+        run_migrate(tmp_path, from_version=1, to_version="latest", write=True)
+    assert {path: path.read_bytes() for path in originals} == originals
 
 
 def write_v1_project(root: Path) -> None:

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("template", ["Makefile", "src/md_blueprints/template_repo/Makefile"])
+@pytest.mark.parametrize("command", ["preview", "preview-smoke"])
+def test_preview_keeps_existing_source_when_selection_fails(tmp_path: Path, template: str, command: str) -> None:
+    repository = Path(__file__).resolve().parents[1]
+    shutil.copyfile(repository / template, tmp_path / "Makefile")
+    source = tmp_path / ".dive-preview/src/dive.tsx"
+    source.parent.mkdir(parents=True)
+    original = "export default function ExistingDive() { return null; }\n"
+    source.write_text(original, encoding="utf-8")
+
+    result = subprocess.run(
+        ["make", "-o", "false", "CLI=false", command, "missing-blueprint"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert source.read_text(encoding="utf-8") == original
+    assert "npm" not in result.stdout

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -307,6 +307,100 @@ resources:
         Project(tmp_path).validate(targets=["preview"], branch="feature/status")
 
 
+def write_staging_share_project(tmp_path: Path, *, staging_share_name: str) -> Project:
+    blueprint_dir = tmp_path / "blueprints" / "data"
+    blueprint_dir.mkdir(parents=True)
+    (tmp_path / "motherduck.yml").write_text(
+        """
+schemaVersion: 1
+repository:
+  name: staging-share
+include:
+  - blueprints/*/blueprint.yml
+targets:
+  preview:
+    mode: preview
+    environment: motherduck-staging
+    deployment:
+      identity: staging service account
+  staging:
+    mode: production
+    environment: motherduck-staging
+    deployment:
+      identity: staging service account
+  prod:
+    mode: production
+    environment: motherduck-production
+    deployment:
+      identity: production service account
+""".lstrip(),
+        encoding="utf-8",
+    )
+    (blueprint_dir / "blueprint.yml").write_text(
+        f"""
+schemaVersion: 1
+name: data
+title: Data
+resources:
+  shares:
+    data:
+      name: shared_data
+      database: analytics
+      targets:
+        preview:
+          name: shared_data_preview_${{target.branch_slug}}
+          database: analytics_preview_${{target.branch_slug}}
+        staging:
+          name: {staging_share_name}
+""".lstrip(),
+        encoding="utf-8",
+    )
+    return Project(tmp_path)
+
+
+def test_staging_and_production_share_names_must_differ(tmp_path: Path) -> None:
+    project = write_staging_share_project(tmp_path, staging_share_name="shared_data")
+
+    with pytest.raises(ValidationError, match="staging and prod share names must differ"):
+        project.validate()
+
+
+def test_staging_and_production_databases_may_share_a_name(tmp_path: Path) -> None:
+    project = write_staging_share_project(tmp_path, staging_share_name="shared_data_staging")
+
+    assert project.validate()
+    assert project.preview_stable_target() == "staging"
+    assert project.render_all("staging")[0].shares["data"]["database"] == "analytics"
+    assert project.render_all("prod")[0].shares["data"]["database"] == "analytics"
+
+
+def test_staging_uses_a_distinct_production_environment(tmp_path: Path) -> None:
+    project = write_staging_share_project(tmp_path, staging_share_name="shared_data_staging")
+    targets = project.manifest["targets"]
+    assert isinstance(targets, dict)
+    staging = targets["staging"]
+    assert isinstance(staging, dict)
+    staging["environment"] = "motherduck-production"
+    preview = targets["preview"]
+    assert isinstance(preview, dict)
+    preview["environment"] = "motherduck-production"
+
+    with pytest.raises(ValidationError, match="must differ from targets.prod.environment"):
+        project._validate_deployment_topology()
+
+
+def test_roles_deploy_to_staging_like_production(tmp_path: Path) -> None:
+    project = write_staging_share_project(tmp_path, staging_share_name="shared_data_staging")
+    blueprint = project.blueprints[0]
+    resources = blueprint.raw["resources"]
+    assert isinstance(resources, dict)
+    resources["roles"] = {"analyst": {"name": "analyst"}}
+
+    rendered = project.render_all("staging")
+
+    assert rendered[0].roles["analyst"]["deploy"] is True
+
+
 def test_dive_status_rejects_unknown_value(tmp_path: Path) -> None:
     blueprint_dir = tmp_path / "blueprints" / "unknown-status"
     source_dir = blueprint_dir / "src"

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -46,6 +46,20 @@ def write_producer(root: Path, output: str = "data") -> None:
     )
 
 
+def test_scaffold_rejects_root_symlink_outside_repository(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    write_root(root)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (root / "guides").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValidationError, match="must stay within"):
+        run_new(root, "guide", "metrics")
+
+    assert list(outside.iterdir()) == []
+
+
 def test_all_typed_scaffolds_generate_a_valid_repository(tmp_path: Path) -> None:
     write_root(tmp_path)
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+@pytest.mark.parametrize("prefix", ["", "src/md_blueprints/template_repo/"])
+@pytest.mark.parametrize("event", ["pull_request", "push"])
+def test_environment_migration_validates_without_deploying_untrusted_configuration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, prefix: str, event: str,
+) -> None:
+    root = Path(__file__).resolve().parents[1]
+    workflow = yaml.safe_load((root / prefix / ".github/workflows/deploy_blueprints.yaml").read_text())
+    step = next(step for step in workflow["jobs"]["compute_changes"]["steps"] if step.get("id") == "topology")
+    source = step["run"].split("python - <<'PY'\n")[1].split("\nPY")[0]
+    manifest = yaml.safe_load((root / "motherduck.yml").read_text())
+    legacy = {"targets": {"preview": {"mode": "preview"}}}
+    if event == "push":
+        manifest["targets"]["prod"].pop("environment")
+    (tmp_path / "motherduck.yml").write_text(yaml.safe_dump(manifest))
+    output = tmp_path / "outputs"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("EVENT_NAME", event)
+    monkeypatch.setenv("BASE_REF", "main")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+    monkeypatch.setattr(subprocess, "check_output", lambda *args, **kwargs: yaml.safe_dump(legacy))
+
+    if event == "push":
+        with pytest.raises(SystemExit, match="must declare environment"):
+            exec(compile(source, "deploy_blueprints.yaml", "exec"), {})
+        assert not output.exists()
+    else:
+        exec(compile(source, "deploy_blueprints.yaml", "exec"), {})
+        values = dict(line.split("=", 1) for line in output.read_text().splitlines())
+        assert values["deployment_enabled"] == "false"
+        assert values["environment"] == ""
+        assert values["target"] == "preview"


### PR DESCRIPTION
Make the first Blueprints deployment easier to understand and remove failure cases that could surprise customers. This simplifies the README and generated template, adds named action inputs, and completes the conventional preview/production setup with optional staging.

### Codex description

- Give customers one working example-deployment path, shorter setup guidance, and a small PR checklist.
- Use named action inputs and environment-scoped credentials across maintained and generated workflows; support optional staging and release-based production promotion.
- Reject empty selections and unsafe file paths, validate migrations before writing, correct Doctor results, and simplify rendering and local setup.
- Verified 197 tests, strict typing, lint, dependency audits, workflow checks, package installation, and generated example builds.
