### PR TITLE
chore: prepare blueprints v0.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ Update this file in every pull request. Add entries under `Unreleased` until the
 
 ## Unreleased
 
+## v0.4.1 - 2026-09-05
+
 ### Fixed
+
+- Keep the canonical template repository validation-only during publication; customer repositories retain automatic deployments.
 
 - Allow environment-migration pull requests to finish validation with deployment disabled when the base branch has no environment metadata; live deployments still require complete configuration.
 

--- a/src/md_blueprints/template_repo/.github/workflows/deploy_blueprints.yaml
+++ b/src/md_blueprints/template_repo/.github/workflows/deploy_blueprints.yaml
@@ -255,6 +255,7 @@ jobs:
     name: Deploy Preview Blueprints
     needs: compute_changes
     if: >-
+      github.repository != 'motherduckdb/blueprints-template' &&
       needs.compute_changes.outputs.changed_blueprints != '[]' &&
       needs.compute_changes.outputs.target == 'preview' &&
       needs.compute_changes.outputs.deployment_enabled == 'true' &&
@@ -352,6 +353,7 @@ jobs:
     name: Deploy ${{ needs.compute_changes.outputs.target }} Blueprints
     needs: compute_changes
     if: >-
+      github.repository != 'motherduckdb/blueprints-template' &&
       needs.compute_changes.outputs.changed_blueprints != '[]' &&
       needs.compute_changes.outputs.target != 'preview' &&
       github.event_name != 'release'
@@ -412,6 +414,7 @@ jobs:
     name: Deploy Released Production Blueprints
     needs: compute_changes
     if: >-
+      github.repository != 'motherduckdb/blueprints-template' &&
       github.event_name == 'release' &&
       needs.compute_changes.outputs.staging_enabled == 'true' &&
       needs.compute_changes.outputs.deployment_enabled == 'true'

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -7,6 +7,15 @@ import pytest
 import yaml
 
 
+def test_canonical_template_validates_without_live_deployment() -> None:
+    root = Path(__file__).resolve().parents[1]
+    path = root / "src/md_blueprints/template_repo/.github/workflows/deploy_blueprints.yaml"
+    jobs = yaml.safe_load(path.read_text())["jobs"]
+    assert "if" not in jobs["compute_changes"]
+    for name in ("deploy-preview", "deploy-stable", "deploy-release-production"):
+        assert "github.repository != 'motherduckdb/blueprints-template' &&" in jobs[name]["if"]
+
+
 @pytest.mark.parametrize("prefix", ["", "src/md_blueprints/template_repo/"])
 @pytest.mark.parametrize("event", ["pull_request", "push"])
 def test_environment_migration_validates_without_deploying_untrusted_configuration(


### PR DESCRIPTION
Prepare v0.4.1 for publication. The canonical template should validate its generated contents without needing MotherDuck credentials; customer copies keep their automatic deployments.

### Codex description

- Mark the shipped changes as v0.4.1 in the changelog.
- Keep live deployment jobs disabled only in motherduckdb/blueprints-template, with a regression check for that boundary.
