### PR TITLE
fix: publish the action through GitHub without PyPI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -103,7 +103,6 @@ jobs:
         env:
           TEMPLATE_PUSH_TOKEN: ${{ secrets.BLUEPRINTS_TEMPLATE_PUSH_TOKEN }}
           TEMPLATE_REPOSITORY: motherduckdb/blueprints-template
-          PYPI_PROJECT: md-blueprints
         run: ./scripts/check-release-external-setup.sh
 
   publish-template:
@@ -193,36 +192,11 @@ jobs:
             gh release create "$tag" -R "$TEMPLATE_REPOSITORY" --verify-tag --title "$tag" --notes-file release-artifacts/RELEASE_NOTES.md
           fi
 
-  publish-pypi:
-    name: Publish PyPI Package
-    needs:
-      - build
-      - release-preflight
-      - publish-template
-    if: github.repository == 'motherduckdb/motherduck-blueprints' && startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    environment: pypi
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: md-blueprints-dist
-          path: release-artifacts
-
-      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
-        with:
-          packages-dir: release-artifacts/dist
-          attestations: true
-
   finalize-release:
     name: Publish GitHub Release and Action Alias
     needs:
       - build
       - publish-template
-      - publish-pypi
     if: github.repository == 'motherduckdb/motherduck-blueprints' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Update this file in every pull request. Add entries under `Unreleased` until the
 
 ## Unreleased
 
+- Publish the action, template, and distribution assets through GitHub without a PyPI publisher or availability dependency. Reject already-existing GitHub tags when preparing a new version.
+
 - Prepare version 0.5.0 for the native CLI and reusable workflow integration.
 
 - Handle the native CLI's multiple JSON result arrays and empty DDL output, fixing failures after successful multi-statement deployments.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,8 @@
 
 ## Tooling and Release
 
+- Publish the action, template, and release assets through GitHub without a PyPI publisher. Version checks reject existing GitHub releases and tags. [#67](https://github.com/motherduckdb/motherduck-blueprints/pull/67)
+
 - Prepare version 0.5.0. Use the tested native CLI for import and CLI smoke checks, while bulk CI deployment keeps the Python runtime after live cycle comparison. [#66](https://github.com/motherduckdb/motherduck-blueprints/pull/66)
 
 ## Compatibility

--- a/docs/tooling-and-schema-versioning.md
+++ b/docs/tooling-and-schema-versioning.md
@@ -9,7 +9,7 @@ Customers should upgrade the exact CLI, reusable workflow, and any direct action
 
 ## CLI and Action Pinning
 
-Generated repositories pin the Blueprints CLI version in the `Makefile` `CLI_VERSION` variable. `make setup` installs `md-blueprints` from the matching Git tag in this repository. The same wheel and source distribution are published to PyPI and attached to the GitHub Release.
+Generated repositories pin the Blueprints CLI version in the `Makefile` `CLI_VERSION` variable. `make setup` installs `md-blueprints` from the matching Git tag in this repository. The wheel and source distribution are attached to the GitHub Release. A PyPI project or publisher is not required to distribute the action or CLI.
 
 For export or live commands, install the supported native MotherDuck CLI:
 
@@ -117,15 +117,16 @@ Stable `vMAJOR.MINOR.PATCH` tag pushes run the release workflow. The workflow tr
 3. Smoke test the installed wheel as an internal packaging check.
 4. Smoke test the local action wrapper.
 5. Generate a reproducible CycloneDX SBOM and attest every release artifact.
-6. Verify the generated-template repository, PyPI trusted publisher, and protected release environments.
+6. Verify the generated-template repository and protected release environments.
 7. Install the built wheel, generate the customer template with an exact action tag, and push it to `motherduckdb/blueprints-template`.
 8. Require the generated repository's triggered workflow to pass against that exact action tag.
-9. Publish the wheel and source distribution to PyPI through trusted publishing.
-10. Attach the distributions and SBOM to the GitHub Release, then update the compatibility-only floating major alias.
+9. Attach the distributions and SBOM to the GitHub Release, then update the compatibility-only floating major alias.
 
-The action installs the tagged checkout directly, generated repositories install local tooling from the matching Git tag, and Python users can install the identical package from PyPI. The floating major tag remains available for compatibility but generated repositories do not depend on it.
+The action installs the tagged checkout directly, generated repositories install local tooling from the matching Git tag, and built Python distributions are attached to the GitHub Release. The floating major tag remains available for compatibility but generated repositories do not depend on it.
 
-One-time template setup: create `motherduckdb/blueprints-template`, mark it as a GitHub template repository, and add a `BLUEPRINTS_TEMPLATE_PUSH_TOKEN` secret that can force-push to that repository. Tagged releases fail before publishing when this setup is missing; the template push is part of the release contract, not an optional best-effort step.
+Marketplace listing is configured through GitHub's release UI. Any required GitHub Marketplace agreement must be accepted by an authorized organization maintainer. The automated release workflow publishes the repository release and action tags without relying on PyPI.
+
+One-time template setup: create `motherduckdb/blueprints-template`, mark it as a GitHub template repository, and add a `BLUEPRINTS_TEMPLATE_PUSH_TOKEN` secret that can push to that repository. Tagged releases fail before publishing when this setup is missing; the template push is part of the release contract, not an optional best-effort step.
 
 Before creating a release tag:
 

--- a/scripts/check-release-external-setup.sh
+++ b/scripts/check-release-external-setup.sh
@@ -5,14 +5,9 @@
 set -euo pipefail
 
 TEMPLATE_REPOSITORY="${TEMPLATE_REPOSITORY:-motherduckdb/blueprints-template}"
-PYPI_PROJECT="${PYPI_PROJECT:-md-blueprints}"
-PYPI_JSON_BASE_URL="${PYPI_JSON_BASE_URL:-https://pypi.org/pypi}"
-ALLOW_PYPI_PENDING_PUBLISHER="${ALLOW_PYPI_PENDING_PUBLISHER:-1}"
-export PYPI_JSON_BASE_URL ALLOW_PYPI_PENDING_PUBLISHER
-
 if [ -z "${TEMPLATE_PUSH_TOKEN:-}" ]; then
   echo "BLUEPRINTS_TEMPLATE_PUSH_TOKEN is not configured." >&2
-  echo "Create ${TEMPLATE_REPOSITORY}, mark it as a template repository, and add a token that can force-push to it." >&2
+  echo "Create ${TEMPLATE_REPOSITORY}, mark it as a template repository, and add a token that can push to it." >&2
   exit 1
 fi
 
@@ -43,36 +38,4 @@ if payload.get("permissions", {}).get("push") is not True:
         "Grant Contents: Read and write access to the template repository and approve any pending org request."
     )
 print(f"Template repository OK: {repository}")
-PY
-
-python3 - "$PYPI_PROJECT" <<'PY'
-from __future__ import annotations
-
-import json
-import os
-import sys
-import urllib.error
-import urllib.request
-
-project = sys.argv[1]
-base_url = os.environ["PYPI_JSON_BASE_URL"].rstrip("/")
-allow_pending = os.environ["ALLOW_PYPI_PENDING_PUBLISHER"] == "1"
-try:
-    with urllib.request.urlopen(f"{base_url}/{project}/json", timeout=10) as response:
-        payload = json.loads(response.read().decode("utf-8"))
-except urllib.error.HTTPError as exc:
-    if exc.code == 404 and allow_pending:
-        print(
-            f"PyPI project {project!r} is not registered yet; assuming a pending trusted publisher "
-            "is configured to create it on first publish."
-        )
-        raise SystemExit(0) from exc
-    if exc.code == 404:
-        raise SystemExit(
-            f"PyPI project {project!r} is not registered. Register a pending trusted publisher "
-            "for this repository, release.yaml, and the pypi environment before tagging a release."
-        ) from exc
-    raise
-
-print(f"PyPI project OK: {payload['info']['name']}")
 PY

--- a/scripts/check-version-available.sh
+++ b/scripts/check-version-available.sh
@@ -3,8 +3,6 @@
 set -euo pipefail
 
 REPOSITORY="${GITHUB_REPOSITORY:-motherduckdb/motherduck-blueprints}"
-PYPI_JSON_BASE_URL="${PYPI_JSON_BASE_URL:-https://pypi.org/pypi}"
-PYPI_PROJECT="${PYPI_PROJECT:-md-blueprints}"
 
 version="$(python3 - <<'PY'
 import pathlib
@@ -31,18 +29,17 @@ if [[ "$release_result" != *"HTTP 404"* ]]; then
   exit 1
 fi
 
-status="$(curl --silent --output /dev/null --write-out '%{http_code}' "${PYPI_JSON_BASE_URL%/}/${PYPI_PROJECT}/${version}/json")"
-case "$status" in
-  404)
-    ;;
-  200)
-    echo "Version ${version} is already published on PyPI; bump the package version before merging more changes." >&2
-    exit 1
-    ;;
-  *)
-    echo "Could not verify md-blueprints ${version} availability on PyPI (HTTP ${status})." >&2
-    exit 1
-    ;;
-esac
+set +e
+tag_result="$(gh api "repos/${REPOSITORY}/git/ref/tags/v${version}" 2>&1)"
+tag_status=$?
+set -e
+if [ "$tag_status" -eq 0 ]; then
+  echo "Version ${version} already has a GitHub tag; choose a new version instead of replacing the tag." >&2
+  exit 1
+fi
+if [[ "$tag_result" != *"HTTP 404"* ]]; then
+  echo "Could not verify GitHub tag availability for v${version}: ${tag_result}" >&2
+  exit 1
+fi
 
 echo "Version available for future release: ${version}"

--- a/src/md_blueprints/template_repo/docs/tooling-and-schema-versioning.md
+++ b/src/md_blueprints/template_repo/docs/tooling-and-schema-versioning.md
@@ -9,7 +9,7 @@ Customers should upgrade the exact CLI, reusable workflow, and any direct action
 
 ## CLI and Action Pinning
 
-Generated repositories pin the Blueprints CLI version in the `Makefile` `CLI_VERSION` variable. `make setup` installs `md-blueprints` from the matching Git tag in this repository. The same wheel and source distribution are published to PyPI and attached to the GitHub Release.
+Generated repositories pin the Blueprints CLI version in the `Makefile` `CLI_VERSION` variable. `make setup` installs `md-blueprints` from the matching Git tag in this repository. The wheel and source distribution are attached to the GitHub Release. A PyPI project or publisher is not required to distribute the action or CLI.
 
 For export or live commands, install the supported native MotherDuck CLI:
 
@@ -117,15 +117,16 @@ Stable `vMAJOR.MINOR.PATCH` tag pushes run the release workflow. The workflow tr
 3. Smoke test the installed wheel as an internal packaging check.
 4. Smoke test the local action wrapper.
 5. Generate a reproducible CycloneDX SBOM and attest every release artifact.
-6. Verify the generated-template repository, PyPI trusted publisher, and protected release environments.
+6. Verify the generated-template repository and protected release environments.
 7. Install the built wheel, generate the customer template with an exact action tag, and push it to `motherduckdb/blueprints-template`.
 8. Require the generated repository's triggered workflow to pass against that exact action tag.
-9. Publish the wheel and source distribution to PyPI through trusted publishing.
-10. Attach the distributions and SBOM to the GitHub Release, then update the compatibility-only floating major alias.
+9. Attach the distributions and SBOM to the GitHub Release, then update the compatibility-only floating major alias.
 
-The action installs the tagged checkout directly, generated repositories install local tooling from the matching Git tag, and Python users can install the identical package from PyPI. The floating major tag remains available for compatibility but generated repositories do not depend on it.
+The action installs the tagged checkout directly, generated repositories install local tooling from the matching Git tag, and built Python distributions are attached to the GitHub Release. The floating major tag remains available for compatibility but generated repositories do not depend on it.
 
-One-time template setup: create `motherduckdb/blueprints-template`, mark it as a GitHub template repository, and add a `BLUEPRINTS_TEMPLATE_PUSH_TOKEN` secret that can force-push to that repository. Tagged releases fail before publishing when this setup is missing; the template push is part of the release contract, not an optional best-effort step.
+Marketplace listing is configured through GitHub's release UI. Any required GitHub Marketplace agreement must be accepted by an authorized organization maintainer. The automated release workflow publishes the repository release and action tags without relying on PyPI.
+
+One-time template setup: create `motherduckdb/blueprints-template`, mark it as a GitHub template repository, and add a `BLUEPRINTS_TEMPLATE_PUSH_TOKEN` secret that can push to that repository. Tagged releases fail before publishing when this setup is missing; the template push is part of the release contract, not an optional best-effort step.
 
 Before creating a release tag:
 

--- a/tests/test_release_external_setup.py
+++ b/tests/test_release_external_setup.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
-import contextlib
-import json
 import os
 import subprocess
-import threading
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Iterator
 
+import pytest
 import yaml
 
 from md_blueprints import __version__
@@ -16,129 +12,89 @@ from md_blueprints import __version__
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_release_gates_all_distribution_channels() -> None:
+def test_release_gates_github_publication_on_verified_template() -> None:
     workflow_text = (REPO_ROOT / ".github/workflows/release.yaml").read_text(encoding="utf-8")
-    workflow = yaml.safe_load(workflow_text)
-    jobs = workflow["jobs"]
-
+    jobs = yaml.safe_load(workflow_text)["jobs"]
     assert '- "v*.*.*"' in workflow_text
     assert jobs["release-preflight"]["needs"] == "build"
     assert set(jobs["publish-template"]["needs"]) == {"build", "release-preflight"}
-    assert set(jobs["publish-pypi"]["needs"]) == {"build", "release-preflight", "publish-template"}
-    assert set(jobs["finalize-release"]["needs"]) == {"build", "publish-template", "publish-pypi"}
+    assert set(jobs["finalize-release"]["needs"]) == {"build", "publish-template"}
+    assert "publish-pypi" not in jobs
+    assert "pypa/gh-action-pypi-publish" not in workflow_text
     build_steps = {step.get("name") for step in jobs["build"]["steps"]}
     assert "Publish GitHub Release" not in build_steps
     assert "Generate dependency SBOM" in build_steps
     assert "Attest release artifacts" in build_steps
-
-    publish_template_steps = jobs["publish-template"]["steps"]
-    generate_step = next(
-        step for step in publish_template_steps if step.get("name") == "Generate template repository from release wheel"
-    )
-    assert "release-artifacts/dist/md_blueprints-*.whl" in generate_step["run"]
-    assert any(step.get("name") == "Verify generated template workflow" for step in publish_template_steps)
+    steps = jobs["publish-template"]["steps"]
+    generate = next(step for step in steps if step.get("name") == "Generate template repository from release wheel")
+    assert "release-artifacts/dist/md_blueprints-*.whl" in generate["run"]
+    assert any(step.get("name") == "Verify generated template workflow" for step in steps)
     assert jobs["publish-template"]["environment"] == "motherduck-release"
-    assert jobs["publish-pypi"]["environment"] == "pypi"
     assert "release-artifacts/dist/*" in workflow_text
     assert "git merge-base --is-ancestor" in workflow_text
 
 
 def test_release_external_check_accepts_writable_template_repository(tmp_path: Path) -> None:
-    result = run_release_external_check(tmp_path, pypi_status=200)
-
+    result = run_release_external_check(tmp_path)
     assert result.returncode == 0
     assert "Template repository OK: motherduckdb/blueprints-template" in result.stdout
-    assert "PyPI project OK: md-blueprints" in result.stdout
-
-
-def test_release_external_check_accepts_pending_pypi_publisher(tmp_path: Path) -> None:
-    result = run_release_external_check(tmp_path, pypi_status=404)
-
-    assert result.returncode == 0
-    assert "pending trusted publisher" in result.stdout
+    assert "PyPI" not in result.stdout
 
 
 def test_release_external_check_requires_template_push_permission(tmp_path: Path) -> None:
-    result = run_release_external_check(tmp_path, pypi_status=200, template_push=False)
-
+    result = run_release_external_check(tmp_path, template_push=False)
     assert result.returncode == 1
     assert "cannot push" in result.stderr
     assert "approve any pending org request" in result.stderr
 
 
 def test_release_external_check_requires_template_repository_mode(tmp_path: Path) -> None:
-    result = run_release_external_check(tmp_path, pypi_status=200, is_template=False)
-
+    result = run_release_external_check(tmp_path, is_template=False)
     assert result.returncode == 1
     assert "not marked as a GitHub template repository" in result.stderr
-
-
-def test_release_external_check_can_require_registered_pypi_project(tmp_path: Path) -> None:
-    result = run_release_external_check(
-        tmp_path,
-        pypi_status=404,
-        extra_env={"ALLOW_PYPI_PENDING_PUBLISHER": "0"},
-    )
-
-    assert result.returncode == 1
-    assert "Register a pending trusted publisher" in result.stderr
 
 
 def test_release_version_check_accepts_only_stable_semantic_tags() -> None:
     stable = subprocess.run(
         [str(REPO_ROOT / "scripts/check-release-version.sh"), f"v{__version__}"],
-        cwd=REPO_ROOT,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        cwd=REPO_ROOT, text=True, capture_output=True,
     )
     prerelease = subprocess.run(
         [str(REPO_ROOT / "scripts/check-release-version.sh"), f"v{__version__}-rc.1"],
-        cwd=REPO_ROOT,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        cwd=REPO_ROOT, text=True, capture_output=True,
     )
-
     assert stable.returncode == 0
     assert prerelease.returncode == 1
     assert "must match vMAJOR.MINOR.PATCH" in prerelease.stderr
 
 
 def test_version_availability_check_accepts_unpublished_version(tmp_path: Path) -> None:
-    result = run_version_availability_check(tmp_path, github_release_exists=False, pypi_release_exists=False)
-
+    result = run_version_availability_check(tmp_path)
     assert result.returncode == 0
     assert f"Version available for future release: {__version__}" in result.stdout
 
 
-def test_version_availability_check_rejects_existing_github_release(tmp_path: Path) -> None:
-    result = run_version_availability_check(tmp_path, github_release_exists=True, pypi_release_exists=False)
-
+@pytest.mark.parametrize("existing, message", [("release", "GitHub Release"), ("tag", "GitHub tag")])
+def test_version_availability_rejects_existing_github_distribution(tmp_path: Path, existing: str, message: str) -> None:
+    result = run_version_availability_check(tmp_path, existing=existing)
     assert result.returncode == 1
-    assert "already has a GitHub Release" in result.stderr
+    assert f"already has a {message}" in result.stderr
 
 
-def test_version_availability_check_rejects_existing_pypi_release(tmp_path: Path) -> None:
-    result = run_version_availability_check(tmp_path, github_release_exists=False, pypi_release_exists=True)
-
+@pytest.mark.parametrize("error_at", ["release", "tag"])
+def test_version_availability_fails_closed_on_github_errors(tmp_path: Path, error_at: str) -> None:
+    result = run_version_availability_check(tmp_path, error_at=error_at)
     assert result.returncode == 1
-    assert "already published on PyPI" in result.stderr
+    assert "Could not verify GitHub" in result.stderr
 
 
 def run_release_external_check(
-    tmp_path: Path,
-    *,
-    pypi_status: int,
-    template_push: bool = True,
-    is_template: bool = True,
-    extra_env: dict[str, str] | None = None,
+    tmp_path: Path, *, template_push: bool = True, is_template: bool = True,
 ) -> subprocess.CompletedProcess[str]:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     gh = bin_dir / "gh"
-    gh.write_text(
-        """#!/usr/bin/env bash
+    gh.write_text('''#!/usr/bin/env bash
 set -euo pipefail
 if [ "${GH_TOKEN:-}" != "template-token" ]; then
   echo "missing GH_TOKEN" >&2
@@ -149,84 +105,47 @@ if [ "$1" != "api" ] || [ "$2" != "repos/motherduckdb/blueprints-template" ]; th
   exit 2
 fi
 printf '{"is_template":%s,"permissions":{"push":%s}}' "${GH_IS_TEMPLATE}" "${GH_TEMPLATE_PUSH}"
-""",
-        encoding="utf-8",
-    )
+''', encoding="utf-8")
     gh.chmod(0o755)
-
-    with pypi_server(pypi_status) as base_url:
-        env = {
-            **os.environ,
-            "PATH": f"{bin_dir}:{os.environ['PATH']}",
-            "TEMPLATE_PUSH_TOKEN": "template-token",
-            "GH_TEMPLATE_PUSH": "true" if template_push else "false",
-            "GH_IS_TEMPLATE": "true" if is_template else "false",
-            "PYPI_JSON_BASE_URL": base_url,
-        }
-        if extra_env is not None:
-            env.update(extra_env)
-        return subprocess.run(
-            [str(REPO_ROOT / "scripts/check-release-external-setup.sh")],
-            cwd=REPO_ROOT,
-            env=env,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
+    return subprocess.run(
+        [str(REPO_ROOT / "scripts/check-release-external-setup.sh")], cwd=REPO_ROOT,
+        env={**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}", "TEMPLATE_PUSH_TOKEN": "template-token",
+             "GH_TEMPLATE_PUSH": str(template_push).lower(), "GH_IS_TEMPLATE": str(is_template).lower(),
+             "PYPI_JSON_BASE_URL": "http://127.0.0.1:1/unavailable"},
+        text=True, capture_output=True,
+    )
 
 
 def run_version_availability_check(
-    tmp_path: Path,
-    *,
-    github_release_exists: bool,
-    pypi_release_exists: bool,
+    tmp_path: Path, *, existing: str = "", error_at: str = "",
 ) -> subprocess.CompletedProcess[str]:
-    bin_dir = tmp_path / "version-bin"
+    bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     gh = bin_dir / "gh"
-    gh.write_text(
-        "#!/usr/bin/env bash\n"
-        + ("printf '{}\\n'\n" if github_release_exists else "echo 'gh: Not Found (HTTP 404)' >&2\nexit 1\n"),
-        encoding="utf-8",
-    )
+    gh.write_text('''#!/usr/bin/env bash
+set -euo pipefail
+case "$2" in
+  */releases/tags/v*) kind=release ;;
+  */git/ref/tags/v*) kind=tag ;;
+  *) echo "unexpected GitHub endpoint" >&2; exit 2 ;;
+esac
+if [ "$kind" = "$GH_ERROR_AT" ]; then
+  echo 'gh: Service unavailable (HTTP 503)' >&2
+  exit 1
+fi
+if [ "$kind" = "$GH_EXISTING" ]; then
+  printf '{}\\n'
+else
+  echo 'gh: Not Found (HTTP 404)' >&2
+  exit 1
+fi
+''', encoding="utf-8")
     gh.chmod(0o755)
     curl = bin_dir / "curl"
-    curl.write_text(
-        f"#!/usr/bin/env bash\nprintf '{200 if pypi_release_exists else 404}'\n",
-        encoding="utf-8",
-    )
+    curl.write_text("#!/usr/bin/env bash\necho 'Registry access is not part of GitHub releases' >&2\nexit 2\n")
     curl.chmod(0o755)
-
     return subprocess.run(
-        [str(REPO_ROOT / "scripts/check-version-available.sh")],
-        cwd=REPO_ROOT,
-        env={**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"},
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        [str(REPO_ROOT / "scripts/check-version-available.sh")], cwd=REPO_ROOT,
+        env={**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}", "GH_EXISTING": existing, "GH_ERROR_AT": error_at},
+        text=True, capture_output=True,
     )
-
-
-@contextlib.contextmanager
-def pypi_server(status: int) -> Iterator[str]:
-    class Handler(BaseHTTPRequestHandler):
-        def do_GET(self) -> None:
-            if self.path != "/md-blueprints/json":
-                self.send_error(404)
-                return
-            self.send_response(status)
-            self.end_headers()
-            if status == 200:
-                self.wfile.write(json.dumps({"info": {"name": "md-blueprints"}}).encode("utf-8"))
-
-        def log_message(self, format: str, *args: object) -> None:
-            return
-
-    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    try:
-        yield f"http://127.0.0.1:{server.server_port}"
-    finally:
-        server.shutdown()
-        thread.join()


### PR DESCRIPTION
GitHub release publication was blocked by PyPI trusted publishing even though the action installs directly from its GitHub checkout. Remove that unrelated publishing requirement while retaining artifact verification and generated-template validation.

### Codex description

- Remove the PyPI upload job and its dependency from GitHub release finalization.
- Limit release preflight to the GitHub template repository and check version uniqueness against GitHub releases and tags.
- Update distribution documentation and regression tests, including fail-closed checks for GitHub API errors.
- Validation: 294 tests passed across Python 3.10–3.14, all required smoke checks, typing, linting, and dependency audits. The existing v0.4.3 artifacts were attestation-verified and published on GitHub without changing their tag.
