### PR TITLE
feat(guides): initialize and refresh repository context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@ Use top-level `inputs` and `outputs` to connect independently deployed packages.
 
 Use `make new-flight`, `make new-dive`, `make new-guide`, `make new-role`, or `make new-project`. `make new-blueprint` remains an alias for a complete project scaffold.
 
+Use `make init-guides` or `make update-guides` for a repository orientation Guide derived from production declarations. Preserve authored context outside its generated markers and commit `.guide-state.json` with the Guide. Read reported source changes and update business context manually. These commands are local only and never enable deployment. Keep production-derived overview content disabled in preview and staging.
+
 When changing layout, commands, target behavior, or resource semantics, update the relevant public docs in the same PR. Check at least `README.md`, `docs/`, package READMEs, `.github/pull_request_template.md`, and this guide for drift.
 
 ## MotherDuck CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Update this file in every pull request. Add entries under `Unreleased` until the
 
 ## Unreleased
 
+- Add `make init-guides` and `make update-guides` to draft and refresh a private repository overview Guide from production package declarations. Preserve authored context and deployment settings, report source changes for review, and support a dry run without contacting MotherDuck.
+
 - Keep native CLI smoke-test JSON output separate from stderr upgrade notices.
 
 - Prepare package version 0.5.2 for the packaging simplification.

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,13 @@ preview-smoke: $(CLI) ## Build a blueprint Dive preview without starting a dev s
 
 # -- Scaffolding --------------------------------------------------------------
 
+.PHONY: init-guides update-guides
+init-guides: $(CLI) ## Draft a repository overview Guide from the current packages
+	$(CLI) guides init
+
+update-guides: $(CLI) ## Refresh repository Guide facts and report source changes
+	$(CLI) guides update
+
 .PHONY: new-blueprint
 new-blueprint: $(CLI) ## Compatibility alias for a complete project blueprint
 	@test -n "$(ARG)" || { echo "Usage: make new-blueprint <blueprint-name>"; exit 1; }

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ make validate
 
 Edit the generated files in `projects/revenue/`, then open a pull request.
 
+Use `make init-guides` to draft a MotherDuck Guide from your repository's packages and data contracts. Run `make update-guides` as the repository changes. Your notes are preserved, and the Guide stays disabled until you enable deployment. See [initialize and refresh Guides](docs/guides-as-code.md#initialize-and-refresh-from-the-repository).
+
 ## More help
 
 - [Setup and troubleshooting](docs/setup-your-repository.md)

--- a/docs/guides-as-code.md
+++ b/docs/guides-as-code.md
@@ -4,6 +4,39 @@ Use a Guide package when your team wants metric definitions, query conventions, 
 
 This workflow requires `md-blueprints >=0.4.0`. Organization-wide Guides require an admin deployment identity.
 
+## Initialize and refresh from the repository
+
+To draft a Guide from the packages already in your repository, run:
+
+```bash
+make init-guides
+```
+
+This creates `guides/repository-overview/` with a private, disabled Guide. It records production package descriptions, Flights and schedules, Dives and mounts, shares, input/output contracts, and the locations of other Guides and roles. Only packages discovered by `motherduck.yml` are included. Optional examples stay out until enabled.
+
+After adding or changing packages, run:
+
+```bash
+make update-guides
+make validate
+```
+
+`update-guides` also initializes the Guide if it does not exist. Repeating either command without changes leaves the files untouched. For a preview of the changes, use:
+
+```bash
+.venv/bin/md-blueprints guides update --dry-run
+```
+
+Both CLI commands accept `--root PATH`. They always describe the entire repository's production declarations. Existing repositories can call the CLI directly after upgrading if their Makefile does not yet have these targets.
+
+The generated section of `guide.md` tracks added, changed, and removed package declarations. Write business definitions, join rules, tested SQL, and pitfalls under **Reviewed context**, outside the generated markers. Updates preserve those notes, the package README, and the manifest's IDs, access, and deployment settings. Edits inside the generated section cause a conflict instead of being overwritten. Move those edits outside the markers and restore the generated section from Git before retrying.
+
+The command reports changes to declared source files, requirements, package READMEs, and manifests using hashes stored in `.guide-state.json`. Commit that file with the Guide. A code-only change updates the hashes and reports the affected file. Read that file and update the reviewed context as needed. The command does not infer business rules from Python or SQL, copy source code or Flight config, or query live MotherDuck state.
+
+This is a broad orientation Guide with no resource references, so it adds no deployment dependencies. Use separate subject Guides with references for rules governing particular catalog objects, Flights, or Dives. Existing authored and imported Guides are preserved.
+
+Review the diff and enable `resources.guides.overview.deploy: true` only when the production Guide is ready. Its preview and staging overrides remain disabled because the generated content describes production. Publish through the normal repository deployment workflow. Init and update only change local files.
+
 ## 1. Scaffold a Guide package
 
 Create a package below the typed `guides/` root:

--- a/docs/repository-reference.md
+++ b/docs/repository-reference.md
@@ -139,6 +139,8 @@ make validate
 make new-flight events-ingest
 make new-dive events-dashboard INPUT=events-ingest.data
 make new-guide analytics-guide
+make init-guides
+make update-guides
 make new-role analytics-team
 make new-project revenue-overview
 make preview wikipedia-pageviews
@@ -153,6 +155,8 @@ md-blueprints doctor
 Omit `--blueprints` to select all packages; an explicitly empty selection is an error. `doctor` validates all declared targets, including rendered resources, and exits unsuccessfully if the manifest is missing or validation fails. Preview commands preserve the existing Dive entrypoint if source selection fails.
 
 `make new-blueprint NAME` remains a compatibility alias for `make new-project NAME`. For a Dive backed by another repository, use `make new-dive NAME URL=md:_share/...`. If a package declares several Dives, pass `DIVE=<resource-key>` to preview commands.
+
+`make init-guides` drafts a private, disabled repository overview Guide from production declarations. `make update-guides` refreshes its generated facts, preserves authored notes and deployment settings, and reports source changes for review. See [Guides as code](guides-as-code.md#initialize-and-refresh-from-the-repository).
 
 `make validate` renders every declared target, validates contracts and uniqueness, checks Flight Python syntax and source boundaries, and validates Dive mounts and Guide references. `md-blueprints plan` queries live state without mutations. A non-selected stable producer must already expose its declared share or planning fails before deployment.
 

--- a/scripts/package-smoke-test.sh
+++ b/scripts/package-smoke-test.sh
@@ -73,6 +73,8 @@ echo "==> Exercising installed scaffold commands"
 "$INSTALL_VENV/bin/md-blueprints" new guide null --root "$TMP_DIR/generated-template"
 "$INSTALL_VENV/bin/md-blueprints" new role on --root "$TMP_DIR/generated-template"
 "$INSTALL_VENV/bin/md-blueprints" new project 123 --root "$TMP_DIR/generated-template"
+make -C "$TMP_DIR/generated-template" CLI="$INSTALL_VENV/bin/md-blueprints" init-guides
+make -C "$TMP_DIR/generated-template" CLI="$INSTALL_VENV/bin/md-blueprints" update-guides
 "$INSTALL_VENV/bin/md-blueprints" validate --root "$TMP_DIR/generated-template"
 "$INSTALL_VENV/bin/md-blueprints" render \
   --root "$TMP_DIR/generated-template" \

--- a/src/md_blueprints/cli.py
+++ b/src/md_blueprints/cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from .deploy import Deployer, PlanFormatter
 from .diagnostics import report_error
 from .init import run_init
+from .guides import run_guides
 from .importer import run_import
 from .maintenance import run_check_updates, run_doctor
 from .migrations import run_migrate
@@ -60,7 +61,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="md-blueprints",
         usage=(
-            "md-blueprints <init|install-cli|new|import|validate|verify|render|dive-source|changed|plan|deploy|cleanup|doctor|"
+            "md-blueprints <init|guides|install-cli|new|import|validate|verify|render|dive-source|changed|plan|deploy|cleanup|doctor|"
             "check-updates|upgrade|migrate> [options]"
         ),
     )
@@ -86,6 +87,10 @@ def main(argv: list[str] | None = None) -> int:
         names = parse_blueprints(options.blueprints)
         if command == "init":
             run_init(Path(options.init_dir or "."), force=options.force)
+        elif command == "guides":
+            if names is not None or options.target is not None or options.new_name is not None:
+                raise ValidationError("guides covers the whole repository's production declarations. Use --root to select a repository.")
+            run_guides(root, options.init_dir or "", dry_run=options.dry_run)
         elif command == "install-cli":
             install_cli()
         elif command == "new":

--- a/src/md_blueprints/guides.py
+++ b/src/md_blueprints/guides.py
@@ -1,0 +1,234 @@
+"""Refresh a local repository orientation Guide without replacing authored context."""
+from __future__ import annotations
+
+import difflib
+import hashlib
+import json
+from pathlib import Path
+from typing import cast
+
+import yaml
+
+from .project import Project, RenderedBlueprint, require_within
+from .schema import ValidationError
+
+
+NAME = "repository-overview"
+DIRECTORY = Path("guides") / NAME
+BEGIN = "<!-- md-blueprints:repository:start -->"
+END = "<!-- md-blueprints:repository:end -->"
+STATE = ".guide-state.json"
+
+
+def _digest(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _code(value: object) -> str:
+    # Keep manifest text from introducing Markdown headings or managed markers.
+    text = " ".join(str(value).split()).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    return "<code>" + text.replace("`", "&#96;") + "</code>"
+
+
+def _inventory(project: Project) -> tuple[str, dict[str, str]]:
+    lines = [
+        "## Repository facts", "",
+        "These are declarations for the production target, not verified live state. "
+        "Check the source and live catalog before relying on a metric or query.", "",
+    ]
+    sources: dict[str, str] = {}
+
+    def track(path: Path) -> None:
+        path = require_within(path, project.root, "Guide input")
+        sources[path.relative_to(project.root).as_posix()] = _digest(path.read_bytes())
+
+    track(project.manifest_path)
+    raw_by_name = {blueprint.name: blueprint for blueprint in project.blueprints}
+    blueprints = sorted(project.render_all("prod"), key=lambda blueprint: blueprint.name)
+    for blueprint in blueprints:
+        if blueprint.name == NAME:
+            continue
+        raw = raw_by_name[blueprint.name]
+        track(raw.path)
+        readme = raw.dir / "README.md"
+        if readme.exists():
+            track(readme)
+        lines.extend([
+            f"### {_code(blueprint.title)}", "",
+            f"Package: {_code(blueprint.name)}. Manifest: {_code(raw.path.relative_to(project.root))}.", "",
+        ])
+        if blueprint.description:
+            lines.extend([f"Description: {_code(blueprint.description)}", ""])
+        for key, contract in sorted(blueprint.inputs.items()):
+            lines.append(
+                f"- Input {_code(key)} consumes {_code(str(contract['blueprint']) + '.' + str(contract['output']))}."
+            )
+        for key, contract in sorted(blueprint.outputs.items()):
+            lines.append(
+                f"- Output {_code(blueprint.name + '.' + key)} publishes share {_code(contract['name'])} "
+                f"from database {_code(contract['database'])}."
+            )
+        _resources(lines, sources, project, blueprint)
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n", dict(sorted(sources.items()))
+
+
+def _resources(
+    lines: list[str], sources: dict[str, str], project: Project, blueprint: RenderedBlueprint,
+) -> None:
+    groups = [
+        ("Share", blueprint.shares), ("Flight", blueprint.flights), ("Dive", blueprint.dives),
+        ("Guide", blueprint.guides), ("Context", blueprint.contexts), ("Role", blueprint.roles),
+    ]
+    for kind, resources in groups:
+        for key, resource in sorted(resources.items()):
+            label = resource.get("title", resource.get("name", key))
+            details = [f"{kind} {_code(key)}: {_code(label)}"]
+            if resource.get("deploy") is False:
+                details.append("deployment disabled")
+            if kind == "Share":
+                details.append(f"database {_code(resource['database'])}")
+            if kind == "Flight":
+                cron = resource.get("scheduleCron")
+                details.append(f"schedule {_code(cron)}" if cron else "no schedule declared")
+                if resource.get("manageSchedule") is False:
+                    details.append("live schedule is preserved")
+            if kind == "Guide":
+                details.append(f"topic {_code(resource.get('topic', ''))}")
+            for field in ("sourcePath", "requirementsPath"):
+                if field in resource:
+                    path = require_within(Path(str(resource[field])), project.root, "Guide input")
+                    relative = path.relative_to(project.root).as_posix()
+                    sources[relative] = _digest(path.read_bytes())
+                    details.append(f"{'source' if field == 'sourcePath' else 'requirements'} {_code(relative)}")
+            lines.append("- " + ", ".join(details) + ".")
+            if kind == "Dive":
+                mounts = cast(list[dict[str, object]], resource.get("requiredResources", []))
+                for mount in mounts:
+                    selector = next(field for field in ("input", "share", "url") if mount.get(field))
+                    lines.append(
+                        f"  - Mount {_code(mount['alias'])} uses {selector} {_code(mount[selector])}."
+                    )
+
+
+def _safe_path(project: Project, relative: Path) -> Path:
+    path = project.root / relative
+    require_within(path, project.root, "Generated Guide path")
+    if any(parent.is_symlink() for parent in (path, *path.parents) if parent != project.root):
+        raise ValidationError(f"Generated Guide path must not use symlinks: {relative}")
+    return path
+
+
+def run_guides(root: Path, action: str, *, dry_run: bool = False) -> None:
+    if action not in {"init", "update"}:
+        raise ValidationError("Usage: md-blueprints guides <init|update> [--dry-run]")
+    project = Project(root)
+    destination = _safe_path(project, DIRECTORY)
+    paths = {name: _safe_path(project, DIRECTORY / name) for name in ("blueprint.yml", "guide.md", "README.md", STATE)}
+    existing = destination.exists()
+    old_sources: dict[str, str] = {}
+    before: dict[str, str] = {}
+    if existing:
+        if not all(path.is_file() for path in paths.values()):
+            raise ValidationError(f"{DIRECTORY} is not a complete generated Guide. Existing files were preserved.")
+        before = {name: path.read_text(encoding="utf-8") for name, path in paths.items()}
+        state = json.loads(before[STATE])
+        if not isinstance(state, dict) or state.get("version") != 1 or not isinstance(state.get("sources"), dict):
+            raise ValidationError(f"Invalid {DIRECTORY / STATE}. Existing files were preserved.")
+        old_sources = state["sources"]
+        if not all(isinstance(key, str) and isinstance(value, str) for key, value in old_sources.items()):
+            raise ValidationError(f"Invalid source hashes in {DIRECTORY / STATE}")
+        content = before["guide.md"]
+        if content.count(BEGIN) != 1 or content.count(END) != 1:
+            raise ValidationError("Generated Guide markers changed. Restore the markers before updating.")
+        start, end = content.index(BEGIN) + len(BEGIN), content.index(END)
+        if end < start or _digest(content[start:end].encode()) != state.get("generatedHash"):
+            raise ValidationError("Generated Guide facts were edited. Move those edits outside the markers before updating.")
+        owned = next((bp for bp in project.blueprints if bp.path == paths["blueprint.yml"]), None)
+        if owned is None or owned.name != NAME:
+            raise ValidationError(f"Include {DIRECTORY / 'blueprint.yml'} in motherduck.yml before updating Guides.")
+        for blueprint in project.render_all("prod"):
+            if blueprint.name == NAME and str(blueprint.guides.get("overview", {}).get("sourcePath")) != str(paths["guide.md"]):
+                raise ValidationError("The generated overview must keep source: guide.md.")
+        if action == "init":
+            print("Repository Guide already initialized. Run make update-guides to refresh it.")
+            return
+    elif NAME in project.all_blueprint_names():
+        raise ValidationError(f"Blueprint name already exists: {NAME}")
+
+    project.validate()
+    facts, sources = _inventory(project)
+    block = "\n\n" + facts + "\n"
+    if existing:
+        content = before["guide.md"]
+        after = {**before, "guide.md": content[:start] + block + content[end:]}
+    else:
+        after = {
+            "blueprint.yml": yaml.safe_dump({
+                "schemaVersion": 1,
+                "name": NAME,
+                "title": "Repository overview",
+                "description": "Repository orientation and declared data contracts for agents.",
+                "resources": {"guides": {"overview": {
+                    "title": "${repository.name}: repository overview",
+                    "topic": "",
+                    "description": "Package map, data contracts, and reviewed repository conventions.",
+                    "source": "guide.md", "deploy": False, "access": "user",
+                    "changeComment": "Refresh reviewed repository context.",
+                    "targets": {"preview": {"deploy": False}, "staging": {"deploy": False}},
+                }}},
+            }, sort_keys=False),
+            "guide.md": (
+                "# Repository overview\n\n"
+                "## Reviewed context\n\n"
+                "Add metric definitions, join rules, tested SQL, and known pitfalls here. "
+                "Content outside the generated markers is preserved on update.\n\n"
+                + BEGIN + block + END + "\n"
+            ),
+            "README.md": (
+                "# Repository overview Guide\n\n"
+                "Run `make update-guides` after changing packages or source files. "
+                "Review `git diff` and update the reviewed context in `guide.md`. "
+                "Source changes are reported for review, not interpreted as business rules.\n\n"
+                "This orientation Guide has no resource references and does not add deployment dependencies. "
+                "Keep resource-specific rules and references in dedicated Guides.\n\n"
+                "The draft is private and deployment is disabled. After review, enable `deploy` "
+                "for production in `blueprint.yml` and use the normal deployment workflow. "
+                "The content describes production, so preview and staging deployment stay disabled.\n"
+            ),
+        }
+        # Check discovery before creating even a draft in a custom include layout.
+        include = cast(list[str], project.manifest["include"])
+        relative = DIRECTORY / "blueprint.yml"
+        if not any(relative.match(pattern) or relative.match(pattern.replace("/**/", "/")) for pattern in include):
+            raise ValidationError("Add guides/**/blueprint.yml to motherduck.yml include before initializing Guides.")
+    after[STATE] = json.dumps({"version": 1, "generatedHash": _digest(block.encode()), "sources": sources}, indent=2) + "\n"
+
+    changed_sources = [path for path in sorted(set(old_sources) | set(sources)) if old_sources.get(path) != sources.get(path)]
+    changed = {name: content for name, content in after.items() if content != before.get(name)}
+    if not changed:
+        print("Repository Guide is up to date.")
+        return
+    for source in changed_sources:
+        status = "removed" if source not in sources else "added" if source not in old_sources else "changed"
+        print(f"{status}: {source}")
+    if dry_run:
+        for name, content in changed.items():
+            if name == STATE:
+                continue
+            relative_name = (DIRECTORY / name).as_posix()
+            print("".join(difflib.unified_diff(
+                before.get(name, "").splitlines(keepends=True), content.splitlines(keepends=True),
+                fromfile=f"a/{relative_name}", tofile=f"b/{relative_name}",
+            )), end="")
+        print("Dry run. No files written.")
+        return
+    # Refuse to replace files edited while preparing this refresh.
+    for name, original in before.items():
+        if paths[name].read_text(encoding="utf-8") != original:
+            raise ValidationError(f"{paths[name]} changed during refresh. Run the command again.")
+    destination.mkdir(parents=True, exist_ok=existing)
+    for name, content in changed.items():
+        paths[name].write_text(content, encoding="utf-8")
+    print(f"{'Updated' if existing else 'Created'} {DIRECTORY}. Review git diff and run make validate.")
+    print("Review changed source files for context updates. No live resources were changed.")

--- a/src/md_blueprints/template_repo/AGENTS.md
+++ b/src/md_blueprints/template_repo/AGENTS.md
@@ -5,6 +5,7 @@ Read [README.md](README.md) first. This is a customer deployment repository, not
 ## Choose the right task
 
 - New pipeline or dashboard: edit the Wikipedia starter or use `make new-project NAME`.
+- Repository Guide: use `make init-guides`, then `make update-guides` after package changes. Read the reported source changes and maintain business rules outside the generated markers in `guides/repository-overview/guide.md`. Commit `.guide-state.json` with the Guide. These commands only prepare local content and preserve deployment settings. See [Guides as code](docs/guides-as-code.md).
 - Existing MotherDuck assets: follow [adopt existing resources](docs/adopt-existing-resources.md) before creating manifests.
 - Package layout and command reference: [repository reference](docs/repository-reference.md).
 - Field definitions and target overrides: [manifest reference](docs/blueprint-yml-reference.md).

--- a/src/md_blueprints/template_repo/Makefile
+++ b/src/md_blueprints/template_repo/Makefile
@@ -47,6 +47,13 @@ preview-smoke: $(CLI) ## Build a blueprint Dive preview without starting a dev s
 	cd .dive-preview && { test -x node_modules/.bin/vite || npm install; }
 	cd .dive-preview && npm run build
 
+.PHONY: init-guides update-guides
+init-guides: $(CLI) ## Draft a repository overview Guide from the current packages
+	$(CLI) guides init
+
+update-guides: $(CLI) ## Refresh repository Guide facts and report source changes
+	$(CLI) guides update
+
 .PHONY: new-blueprint
 new-blueprint: $(CLI) ## Compatibility alias for a complete project blueprint
 	@test -n "$(ARG)" || { echo "Usage: make new-blueprint <blueprint-name>"; exit 1; }

--- a/src/md_blueprints/template_repo/README.md
+++ b/src/md_blueprints/template_repo/README.md
@@ -72,6 +72,8 @@ make validate
 
 Edit the generated files in `projects/revenue/`, then open a pull request.
 
+Use `make init-guides` to draft a MotherDuck Guide from your repository's packages and data contracts. Run `make update-guides` as the repository changes. Your notes are preserved, and the Guide stays disabled until you enable deployment. See [initialize and refresh Guides](docs/guides-as-code.md#initialize-and-refresh-from-the-repository).
+
 ## More help
 
 - [Setup and troubleshooting](docs/setup-your-repository.md)

--- a/tests/test_guides.py
+++ b/tests/test_guides.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from md_blueprints.cli import main
+from md_blueprints.guides import BEGIN, DIRECTORY, STATE, run_guides
+from md_blueprints.init import run_init
+from md_blueprints.project import Project
+from md_blueprints.scaffold import run_new
+from md_blueprints.schema import ValidationError
+
+
+def snapshot(root: Path) -> dict[str, bytes]:
+    return {str(path.relative_to(root)): path.read_bytes() for path in root.rglob("*") if path.is_file()}
+
+
+def test_init_generates_valid_private_orientation_and_is_idempotent(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    run_init(tmp_path)
+    run_guides(tmp_path, "init")
+    project = Project(tmp_path)
+    assert project.validate()
+    for target in project.target_names():
+        guide = project.render_all(target, branch="test/guides", names=["repository-overview"])[0].guides["overview"]
+        assert guide["deploy"] is False
+        assert guide["access"] == "user"
+        assert guide["references"] == []
+    content = (tmp_path / DIRECTORY / "guide.md").read_text()
+    assert "wikipedia-pageviews-ingest.pageviews" in content
+    assert "wikipedia_pageviews" in content
+    assert "examples/ncs-field-recovery" not in content
+    assert "Package: <code>repository-overview</code>" not in content
+    before = snapshot(tmp_path)
+    run_guides(tmp_path, "init")
+    run_guides(tmp_path, "update")
+    assert snapshot(tmp_path) == before
+    assert "up to date" in capsys.readouterr().out
+
+
+def test_update_adds_changes_and_removes_packages_preserving_notes_and_settings(tmp_path: Path) -> None:
+    run_init(tmp_path)
+    run_guides(tmp_path, "init")
+    directory = tmp_path / DIRECTORY
+    guide_path = directory / "guide.md"
+    guide_path.write_text("Owner-reviewed rule: ignore test accounts.\n\n" + guide_path.read_text() + "\nCustom footer.\n")
+    manifest_path = directory / "blueprint.yml"
+    manifest_path.write_text(manifest_path.read_text().replace("deploy: false", "deploy: true", 1) + "\n# Keep my settings.\n")
+    manifest = manifest_path.read_bytes()
+    run_new(tmp_path, "flight", "events")
+    root_path = tmp_path / "motherduck.yml"
+    root = yaml.safe_load(root_path.read_text())
+    root["include"] = ["flights/**/blueprint.yml", "guides/**/blueprint.yml"]
+    root_path.write_text(yaml.safe_dump(root))
+    path = tmp_path / "flights/wikipedia-pageviews-ingest/blueprint.yml"
+    path.write_text(path.read_text().replace("Wikipedia Pageviews Ingest", "Updated Pageview Ingest"))
+    run_guides(tmp_path, "update")
+    content = guide_path.read_text()
+    assert content.startswith("Owner-reviewed rule")
+    assert content.endswith("Custom footer.\n")
+    assert "Package: <code>events</code>" in content
+    assert "Updated Pageview Ingest" in content
+    assert "dives/wikipedia-pageviews/blueprint.yml" not in content
+    assert manifest_path.read_bytes() == manifest
+    assert Project(tmp_path).validate()
+
+
+def test_source_only_change_is_reported_without_inventing_context(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    run_init(tmp_path)
+    run_guides(tmp_path, "init")
+    capsys.readouterr()
+    path = tmp_path / "flights/wikipedia-pageviews-ingest/src/flight.py"
+    path.write_text(path.read_text() + "\n# Newly reviewed behavior\n")
+    before = (tmp_path / DIRECTORY / "guide.md").read_bytes()
+    run_guides(tmp_path, "update")
+    assert "changed: flights/wikipedia-pageviews-ingest/src/flight.py" in capsys.readouterr().out
+    assert (tmp_path / DIRECTORY / "guide.md").read_bytes() == before
+
+
+@pytest.mark.parametrize("action", ["init", "update"])
+def test_dry_run_writes_nothing_and_update_can_initialize(tmp_path: Path, action: str) -> None:
+    run_init(tmp_path)
+    before = snapshot(tmp_path)
+    assert main(["guides", action, "--root", str(tmp_path), "--dry-run"]) == 0
+    assert snapshot(tmp_path) == before
+    assert main(["guides", action, "--root", str(tmp_path)]) == 0
+    run_new(tmp_path, "role", "analysts")
+    before = snapshot(tmp_path)
+    assert main(["guides", "update", "--root", str(tmp_path), "--dry-run"]) == 0
+    assert snapshot(tmp_path) == before
+
+
+@pytest.mark.parametrize("edit", ["facts", "markers", "state", "source"])
+def test_conflicts_fail_without_writing(tmp_path: Path, edit: str) -> None:
+    run_init(tmp_path)
+    run_guides(tmp_path, "init")
+    path = tmp_path / DIRECTORY / "guide.md"
+    if edit == "facts":
+        path.write_text(path.read_text().replace("## Repository facts", "## My facts"))
+    elif edit == "markers":
+        path.write_text(path.read_text().replace(BEGIN, ""))
+    elif edit == "state":
+        (tmp_path / DIRECTORY / STATE).write_text("[]")
+    else:
+        (path.parent / "other.md").write_text("Other Guide")
+        manifest = path.parent / "blueprint.yml"
+        manifest.write_text(manifest.read_text().replace("source: guide.md", "source: other.md"))
+    before = snapshot(tmp_path)
+    assert main(["guides", "update", "--root", str(tmp_path)]) == 1
+    assert snapshot(tmp_path) == before
+
+
+def test_existing_unmanaged_guide_and_duplicate_slug_are_preserved(tmp_path: Path) -> None:
+    run_init(tmp_path)
+    run_new(tmp_path, "guide", "repository-overview")
+    before = snapshot(tmp_path)
+    with pytest.raises(ValidationError, match="not a complete generated Guide"):
+        run_guides(tmp_path, "update")
+    assert snapshot(tmp_path) == before
+
+
+def test_custom_include_and_invalid_repository_fail_before_writing(tmp_path: Path) -> None:
+    run_init(tmp_path)
+    manifest = tmp_path / "motherduck.yml"
+    root = yaml.safe_load(manifest.read_text())
+    root["include"] = ["flights/**/blueprint.yml", "dives/**/blueprint.yml"]
+    manifest.write_text(yaml.safe_dump(root))
+    before = snapshot(tmp_path)
+    with pytest.raises(ValidationError, match="Add guides"):
+        run_guides(tmp_path, "init")
+    assert snapshot(tmp_path) == before
+
+
+def test_symlink_destination_is_rejected(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    run_init(root)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (root / "guides").symlink_to(outside, target_is_directory=True)
+    with pytest.raises(ValidationError, match="must stay within"):
+        run_guides(root, "init")
+    assert list(outside.iterdir()) == []
+
+
+def test_generation_does_not_copy_flight_config_secrets_or_source(tmp_path: Path) -> None:
+    run_init(tmp_path)
+    manifest = tmp_path / "flights/wikipedia-pageviews-ingest/blueprint.yml"
+    source = yaml.safe_load(manifest.read_text())
+    flight = next(iter(source["resources"]["flights"].values()))
+    flight["config"]["private_setting"] = "do-not-copy-config"
+    flight["secrets"] = ["do-not-copy-secret"]
+    manifest.write_text(yaml.safe_dump(source))
+    run_guides(tmp_path, "init")
+    content = (tmp_path / DIRECTORY / "guide.md").read_text()
+    assert "do-not-copy" not in content
+
+
+@pytest.mark.parametrize("args", [["guides"], ["guides", "delete"], ["guides", "init", "unexpected"], ["guides", "init", "--blueprints", "events"]])
+def test_cli_rejects_invalid_guide_requests(args: list[str], tmp_path: Path) -> None:
+    assert main([*args, "--root", str(tmp_path)]) == 1


### PR DESCRIPTION
The existing Guide scaffold starts empty. Add `make init-guides` and `make update-guides` to draft and refresh a repository overview from production package declarations while preserving authored context and deployment settings.

### Codex description

- Track packages, resources, and data contracts in a managed section. Report source changes for human review without inferring business rules.
- Keep new Guides private with deployment disabled. Preserve existing notes, IDs, access, and settings, reject conflicting edits, and support dry runs.
- Include the commands and documentation in generated customer repositories, with an installed-package smoke test.
- Passed 312 unit tests, manifest validation, mock deployment, example and customer journey smoke tests, package smoke, native CLI smoke, Dive build, strict typing, lint, dependency audits, workflow checks, and release-version checks.
