### PR TITLE
chore: release v0.6.0 with repository Guides and dependency updates

### DIFF
--- a/.github/workflows/reusable_blueprints_doctor.yaml
+++ b/.github/workflows/reusable_blueprints_doctor.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Run blueprints doctor
         id: doctor
         continue-on-error: true
-        uses: motherduckdb/motherduck-blueprints@v0.5.2
+        uses: motherduckdb/motherduck-blueprints@v0.6.0
         with:
           command: doctor
           args: --format github-summary --check-updates

--- a/.github/workflows/reusable_cleanup_preview_blueprints.yaml
+++ b/.github/workflows/reusable_cleanup_preview_blueprints.yaml
@@ -27,7 +27,7 @@ jobs:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
 
       - name: Validate base deployment configuration
-        uses: motherduckdb/motherduck-blueprints@v0.5.2
+        uses: motherduckdb/motherduck-blueprints@v0.6.0
         with:
           command: validate
 
@@ -108,7 +108,7 @@ jobs:
       - name: Cleanup preview blueprints from the branch manifest
         id: cleanup-branch-manifest
         continue-on-error: ${{ github.event_name == 'pull_request' }}
-        uses: motherduckdb/motherduck-blueprints@v0.5.2
+        uses: motherduckdb/motherduck-blueprints@v0.6.0
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         with:
@@ -124,7 +124,7 @@ jobs:
 
       - name: Cleanup preview blueprints from the base manifest
         if: ${{ github.event_name == 'pull_request' }}
-        uses: motherduckdb/motherduck-blueprints@v0.5.2
+        uses: motherduckdb/motherduck-blueprints@v0.6.0
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         with:

--- a/.github/workflows/reusable_deploy_blueprints.yaml
+++ b/.github/workflows/reusable_deploy_blueprints.yaml
@@ -40,7 +40,7 @@ jobs:
           ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
 
       - name: Validate configured targets
-        uses: motherduckdb/motherduck-blueprints@v0.5.2
+        uses: motherduckdb/motherduck-blueprints@v0.6.0
         with:
           command: validate
 
@@ -159,7 +159,7 @@ jobs:
       - name: Compute changed blueprints for pull request
         id: changed-pr
         if: ${{ github.event_name == 'pull_request' }}
-        uses: motherduckdb/motherduck-blueprints@v0.5.2
+        uses: motherduckdb/motherduck-blueprints@v0.6.0
         with:
           command: changed
           args: --base origin/${{ github.base_ref }} --head HEAD --json
@@ -181,7 +181,7 @@ jobs:
       - name: Compute changed blueprints for push
         id: changed-push
         if: ${{ github.event_name == 'push' }}
-        uses: motherduckdb/motherduck-blueprints@v0.5.2
+        uses: motherduckdb/motherduck-blueprints@v0.6.0
         with:
           command: changed
           args: ${{ steps.push-range.outputs.args }}
@@ -189,7 +189,7 @@ jobs:
       - name: Select all blueprints
         id: changed-all
         if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.blueprints == '') }}
-        uses: motherduckdb/motherduck-blueprints@v0.5.2
+        uses: motherduckdb/motherduck-blueprints@v0.6.0
         with:
           command: changed
           args: --all --json
@@ -242,7 +242,7 @@ jobs:
 
       - name: Plan preview blueprints
         id: plan-preview
-        uses: motherduckdb/motherduck-blueprints@v0.5.2
+        uses: motherduckdb/motherduck-blueprints@v0.6.0
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         with:
@@ -253,7 +253,7 @@ jobs:
 
       - name: Deploy preview blueprints
         id: deploy-preview
-        uses: motherduckdb/motherduck-blueprints@v0.5.2
+        uses: motherduckdb/motherduck-blueprints@v0.6.0
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         with:
@@ -314,7 +314,7 @@ jobs:
 
       - name: Plan target blueprints
         id: plan-stable
-        uses: motherduckdb/motherduck-blueprints@v0.5.2
+        uses: motherduckdb/motherduck-blueprints@v0.6.0
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         with:
@@ -335,7 +335,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Deploy target blueprints
-        uses: motherduckdb/motherduck-blueprints@v0.5.2
+        uses: motherduckdb/motherduck-blueprints@v0.6.0
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         with:
@@ -379,7 +379,7 @@ jobs:
 
       - name: Plan released production blueprints
         id: plan-production
-        uses: motherduckdb/motherduck-blueprints@v0.5.2
+        uses: motherduckdb/motherduck-blueprints@v0.6.0
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         with:
@@ -400,7 +400,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Deploy released production blueprints
-        uses: motherduckdb/motherduck-blueprints@v0.5.2
+        uses: motherduckdb/motherduck-blueprints@v0.6.0
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,13 @@ Update this file in every pull request. Add entries under `Unreleased` until the
 
 ## Unreleased
 
-- Update wheel to 0.48.0 while retaining setuptools 84.0.0 for action and package builds.
+## v0.6.0 - 2026-09-11
 
-- Add `make init-guides` and `make update-guides` to draft and refresh a private repository overview Guide from production package declarations. Preserve authored context and deployment settings, report source changes for review, and support a dry run without contacting MotherDuck.
-
-- Keep native CLI smoke-test JSON output separate from stderr upgrade notices.
-
-- Prepare package version 0.5.2 for the packaging simplification.
-
-- Use the asset map for both source-distribution and wheel packaging, removing the separately maintained source manifest. Customer files and upgrade steps are unchanged.
-
-- Update the React Vite plugin to 6.1.1 alongside Vite 8.2.2, retaining React 18 and Arrow 17 compatibility.
+- Add `make init-guides` and `make update-guides` to draft and refresh a private repository overview Guide from production package declarations. Preserve authored context and deployment settings, report source changes for review, and support a dry run without contacting MotherDuck. (#80)
+- Use one asset map for source distributions and wheels, and keep native CLI smoke-test JSON separate from stderr upgrade notices. (#69)
+- Update Vite to 8.2.2, its React plugin to 6.1.1, and Lucide React to 1.42.0. Retain React 18 and Arrow 17 compatibility. (#79, #75, #73)
+- Update action build pins to setuptools 84.0.0 and wheel 0.48.0, plus locked mypy 2.3.1, Ruff 0.16.6, and PyYAML typing definitions. (#76, #71, #74, #78, #72)
+- Publish aligned v0.6.0 CLI, action, and generated-template pins. Existing resource manifests, IDs, and deployment settings need no migration.
 
 ## v0.5.1 - 2026-09-10
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: motherduckdb/motherduck-blueprints@v0.5.1
+      - uses: motherduckdb/motherduck-blueprints@v0.6.0
 ```
 
 ### Deploy to production manually
@@ -124,7 +124,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v7
-      - uses: motherduckdb/motherduck-blueprints@v0.5.1
+      - uses: motherduckdb/motherduck-blueprints@v0.6.0
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         with:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,30 +1,37 @@
 ## Highlights
 
-- Reduce the tooling repository from 191 to 141 source files by assembling shared assets from one authoritative copy. Installed packages retain the docs, schemas, starters, and preview support. [#68](https://github.com/motherduckdb/motherduck-blueprints/pull/68)
-- Add complete validation and manual deployment workflows to the README, including environment-secret setup. [#68](https://github.com/motherduckdb/motherduck-blueprints/pull/68)
+- Initialize and refresh a repository overview Guide with `make init-guides` and `make update-guides`, preserving authored notes and deployment settings. [#80](https://github.com/motherduckdb/motherduck-blueprints/pull/80)
+- Keep installed packages and generated customer repositories aligned through a single asset map. [#69](https://github.com/motherduckdb/motherduck-blueprints/pull/69)
+
+## Features
+
+- Draft a private, disabled Guide from production package declarations, refresh resource and data-contract facts, report source changes for review, and preview updates with `--dry-run`. Business rules remain authored context. [#80](https://github.com/motherduckdb/motherduck-blueprints/pull/80)
+
+## Bug Fixes
+
+- Keep native CLI smoke-test JSON separate from stderr upgrade notices so notices do not break result parsing. [#69](https://github.com/motherduckdb/motherduck-blueprints/pull/69)
 
 ## Maintenance
 
-- Remove duplicate scaffolds and empty optional-root guidance. Merge GitHub protection guidance into the setup guide and remove the outdated tooling devcontainer. [#68](https://github.com/motherduckdb/motherduck-blueprints/pull/68)
-- Generate repository workflow jobs from reusable providers. Repository jobs still test the current checkout, while customer workflows use the release pin. Generated YAML remains checked in for GitHub Actions. [#68](https://github.com/motherduckdb/motherduck-blueprints/pull/68)
+- Assemble both source distributions and wheels from the authoritative asset map, removing a separately maintained source manifest. [#69](https://github.com/motherduckdb/motherduck-blueprints/pull/69)
 
 ## Tooling and Release
 
-- Release v0.5.1 through GitHub with self-contained wheel and source distribution assets. Source checkouts resolve authoritative assets directly, and wheel builds assemble the same files. [#68](https://github.com/motherduckdb/motherduck-blueprints/pull/68)
+- Update preview tooling to Vite 8.2.2 and its React plugin 6.1.1, and update Lucide React to 1.42.0. [#79](https://github.com/motherduckdb/motherduck-blueprints/pull/79) [#75](https://github.com/motherduckdb/motherduck-blueprints/pull/75) [#73](https://github.com/motherduckdb/motherduck-blueprints/pull/73)
+- Update action build pins to setuptools 84.0.0 and wheel 0.48.0, and refresh locked mypy, Ruff, and PyYAML typing dependencies. [#76](https://github.com/motherduckdb/motherduck-blueprints/pull/76) [#71](https://github.com/motherduckdb/motherduck-blueprints/pull/71) [#74](https://github.com/motherduckdb/motherduck-blueprints/pull/74) [#78](https://github.com/motherduckdb/motherduck-blueprints/pull/78) [#72](https://github.com/motherduckdb/motherduck-blueprints/pull/72)
+
+- Align the CLI, reusable workflows, documentation, and generated template on v0.6.0. [Release diff](https://github.com/motherduckdb/motherduck-blueprints/compare/v0.5.1...v0.6.0)
 
 ## Compatibility
 
-**No customer file or resource migration is required.** Schema version 1, resource discovery roots, bound IDs and ownership guards, schedule configuration, targets, secrets, CLI commands, action inputs, and reusable workflow paths remain unchanged. [#68](https://github.com/motherduckdb/motherduck-blueprints/pull/68)
-
-- In generated repositories, run `make upgrade VERSION=0.5.1`, review the diff, then run `make validate`. This updates CLI and action/workflow pins only. Existing expanded workflows are preserved. [#68](https://github.com/motherduckdb/motherduck-blueprints/pull/68)
-- For older templates without `make upgrade`, update `CLI_VERSION` and MotherDuck Blueprints action or reusable-workflow pins manually to `0.5.1` / `v0.5.1`, preserving workflow settings. Direct-action users can use `motherduckdb/motherduck-blueprints@v0.5.1`. [#68](https://github.com/motherduckdb/motherduck-blueprints/pull/68)
-- Adopted Flights, Dives, and Guides do not need re-export, re-import, renaming, or changes to bound IDs. Owner settings and `manageSchedule: false` remain as configured. [#68](https://github.com/motherduckdb/motherduck-blueprints/pull/68)
-- Existing `templates/`, placeholder READMEs, `docs/github-setup.md`, and custom `.devcontainer/` files can remain. Upgrading does not delete them. Only remove old files after checking they are unmodified and unused by custom tooling. Keep populated resource directories and customized files. [#68](https://github.com/motherduckdb/motherduck-blueprints/pull/68)
-- New repositories receive the consolidated setup guide. Optional roots continue to be created on demand, and the optional NCS example remains available. [#68](https://github.com/motherduckdb/motherduck-blueprints/pull/68)
-- Tooling contributors and forks must use the asset map and source manifest when adding shared files, and run `make sync-workflows` after changing reusable jobs. Direct references to removed internal source paths must be updated. Customer CLI and action interfaces are unchanged. [#68](https://github.com/motherduckdb/motherduck-blueprints/pull/68)
+- Schema version 1, existing resource IDs, deployment targets, schedules, and adoption settings are unchanged. The new Guide workflow is opt-in and does not publish content automatically. [#80](https://github.com/motherduckdb/motherduck-blueprints/pull/80) [#69](https://github.com/motherduckdb/motherduck-blueprints/pull/69)
+- Existing repositories can run `make upgrade VERSION=0.6.0`, then `make validate` to install and check the pinned CLI. Use `.venv/bin/md-blueprints guides init` and `.venv/bin/md-blueprints guides update`. Upgrading pins does not add the new Makefile shortcuts. New templates include them. [#80](https://github.com/motherduckdb/motherduck-blueprints/pull/80)
+- React and React DOM remain on 18, and Apache Arrow remains on 17 for the current MotherDuck WASM client. The incompatible standalone major upgrades are excluded. [#77](https://github.com/motherduckdb/motherduck-blueprints/pull/77) [#70](https://github.com/motherduckdb/motherduck-blueprints/pull/70)
+- Custom Dives using Lucide should run their preview build to check icon exports after upgrading the preview dependencies. Repository icon imports and generated examples were checked with Lucide 1.42.0. [#73](https://github.com/motherduckdb/motherduck-blueprints/pull/73)
 
 ## Verification
 
-- Passed 295 unit tests, package installation and assembled-asset checks, upgrade-preservation coverage, mock deployments, preview/example builds, customer-journey checks, typing, and linting before release preparation. Final release checks are run against the v0.5.1 commit. [#68](https://github.com/motherduckdb/motherduck-blueprints/pull/68)
+- Passed 312 unit tests, manifest validation, strict typing and lint, mock deployments, native CLI smoke, preview and generated-example builds, customer journeys, and installed-wheel smoke tests during integration. [#80](https://github.com/motherduckdb/motherduck-blueprints/pull/80) [#71](https://github.com/motherduckdb/motherduck-blueprints/pull/71) [#75](https://github.com/motherduckdb/motherduck-blueprints/pull/75)
+- CI covers Python 3.10–3.14, packaging, workflow lint, and dependency audits. Tagged publication additionally verifies release artifacts and the generated template. [CI](https://github.com/motherduckdb/motherduck-blueprints/actions/workflows/ci.yaml) [Release workflow](https://github.com/motherduckdb/motherduck-blueprints/actions/workflows/release.yaml)
 
-**Full diff:** https://github.com/motherduckdb/motherduck-blueprints/compare/v0.5.0...v0.5.1
+**Full diff:** https://github.com/motherduckdb/motherduck-blueprints/compare/v0.5.1...v0.6.0

--- a/docs/adopt-existing-resources.md
+++ b/docs/adopt-existing-resources.md
@@ -4,7 +4,7 @@ The importer reads existing Flights, Dives, and Guides, creates UUID-bound packa
 
 ## 1. Use the current tooling and intended identity
 
-Import and UUID-bound Flight/Dive updates require Blueprints 0.4.3 or newer. Keep your Makefile and action pins aligned; use `make upgrade VERSION=0.5.1` when upgrading an existing generated repository.
+Import and UUID-bound Flight/Dive updates require Blueprints 0.4.3 or newer. Keep your Makefile and action pins aligned; use `make upgrade VERSION=0.6.0` when upgrading an existing generated repository.
 
 Run `make install-deploy` to install the supported MotherDuck CLI, which bundles its DuckDB runtime. Open a new terminal if `motherduck` is not on your PATH. Run `motherduck login` and `motherduck status` for local read-only export, or provide the selected target's token through your secret manager. For example, `--target prod` reads the token configured by `targets.prod.deployment.tokenEnvVar`, normally `MOTHERDUCK_TOKEN`. Import from the account where the existing resources live; a new service account is not an ownership transfer.
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: motherduckdb/motherduck-blueprints@v0.5.1
+      - uses: motherduckdb/motherduck-blueprints@v0.6.0
 ```
 
 The action installs its own Python dependencies. Validation is the default command and needs no token. For import, it installs the tested MotherDuck CLI and uses `motherduck query --file ... --output json` with the job's environment token. Deployment, planning, verification, and cleanup install the Python deploy dependencies and execute SQL in process. Both paths require the job's environment token. CLI state is isolated under the runner's temporary directory, and SQL is passed through temporary files rather than shell arguments. The adapter handles multiple result arrays and empty DDL output. Flight waits track the submitted run number and fail deployment on a failed or cancelled run.
@@ -47,7 +47,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v7
-      - uses: motherduckdb/motherduck-blueprints@v0.5.1
+      - uses: motherduckdb/motherduck-blueprints@v0.6.0
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         with:
@@ -89,7 +89,7 @@ By default, deployment then reads back resource identities and checks declared s
 For a separate read-only check of existing resources, including disabled imported bindings, use:
 
 ```yaml
-- uses: motherduckdb/motherduck-blueprints@v0.5.1
+- uses: motherduckdb/motherduck-blueprints@v0.6.0
   env:
     MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
   with:

--- a/docs/guides-as-code.md
+++ b/docs/guides-as-code.md
@@ -6,7 +6,7 @@ This workflow requires `md-blueprints >=0.4.0`. Organization-wide Guides require
 
 ## Initialize and refresh from the repository
 
-To draft a Guide from the packages already in your repository, run:
+With `md-blueprints >=0.6.0`, draft a Guide from the packages already in your repository:
 
 ```bash
 make init-guides

--- a/docs/setup-your-repository.md
+++ b/docs/setup-your-repository.md
@@ -118,7 +118,7 @@ Promotion reconciles the tagged code under the production service account. It do
 
 ## Keep the tooling current
 
-Run `make upgrade` to update the CLI, reusable workflows, and any direct action pins together and show the diff. It does not commit, push, or overwrite workflow settings. Use `make upgrade VERSION=0.5.1` to select a release, or `.venv/bin/md-blueprints upgrade` for a dry run. The scheduled Doctor workflow reports outdated tooling and configuration problems. See [upgrades and migrations](tooling-and-schema-versioning.md).
+Run `make upgrade` to update the CLI, reusable workflows, and any direct action pins together and show the diff. It does not commit, push, or overwrite workflow settings. Use `make upgrade VERSION=0.6.0` to select a release, or `.venv/bin/md-blueprints upgrade` for a dry run. The scheduled Doctor workflow reports outdated tooling and configuration problems. See [upgrades and migrations](tooling-and-schema-versioning.md).
 
 For existing resources, run `make install-deploy`, authenticate with `motherduck login`, check `motherduck status`, then run `make export`. Follow the [adoption guide](adopt-existing-resources.md) before enabling deployment. Other live local commands require the target token through your secret manager. For a custom workflow, see [GitHub Action inputs](github-action.md).
 

--- a/docs/tooling-and-schema-versioning.md
+++ b/docs/tooling-and-schema-versioning.md
@@ -24,7 +24,7 @@ Run `make upgrade` to update `CLI_VERSION` in `Makefile` and every Blueprints wo
 Customer workflows should pin an immutable release tag:
 
 ```yaml
-- uses: motherduckdb/motherduck-blueprints@v0.5.1
+- uses: motherduckdb/motherduck-blueprints@v0.6.0
   with:
     command: validate
 ```
@@ -131,7 +131,7 @@ One-time template setup: create `motherduckdb/blueprints-template`, mark it as a
 Before creating a release tag:
 
 ```bash
-make release-check TAG=v0.5.1
+make release-check TAG=v0.6.0
 make release-external-check
 make validate
 make mock-test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "md-blueprints"
-version = "0.5.2"
+version = "0.6.0"
 description = "Versioned MotherDuck Blueprints CLI for validation, planning, deployment, cleanup, and migrations."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/md_blueprints/__init__.py
+++ b/src/md_blueprints/__init__.py
@@ -1,3 +1,3 @@
 """MotherDuck Blueprints CLI package."""
 
-__version__ = "0.5.2"
+__version__ = "0.6.0"

--- a/uv.lock
+++ b/uv.lock
@@ -407,7 +407,7 @@ wheels = [
 
 [[package]]
 name = "md-blueprints"
-version = "0.5.2"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "json5" },


### PR DESCRIPTION
Prepare v0.6.0 after reviewing the open dependency PRs. This release ships repository Guide initialization and refresh, unified package assets, and the eight compatible dependency updates. React DOM 19 and Arrow 21 remain excluded because their peer requirements conflict with the current preview stack.

### Codex description

- Align package metadata, the lockfile, reusable action pins, and documentation on 0.6.0.
- Add linked release notes covering all changes since v0.5.1 and explain how existing repositories can use the new Guide commands.
- Preserve schema version 1, resource identities, deployment settings, React 18, and Arrow 17.
- Validate the combined release with unit tests, strict typing, lint, mock deployment, native CLI, preview/example/customer journey checks, package smoke tests, dependency audits, and workflow checks.
